### PR TITLE
New way to couple SuperFast(t) and emis model

### DIFF
--- a/docs/src/composing_models.md
+++ b/docs/src/composing_models.md
@@ -79,7 +79,7 @@ emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", t, lon, lat, lev, Δz; dty
 
 
 model_noemis = couple(SuperFast(t),FastJX(t)) # A model with chemistry and photolysis, but no emissions.
-model_withemis = couple(SuperFast(t), FastJX(t), emis) # The same model with emissions.
+model_withemis = couple(SuperFast(t), FastJX(t), emis, NeiEmissions(t)) # The same model with emissions.
 
 sys_noemis = structural_simplify(get_mtk(model_noemis))
 sys_withemis = structural_simplify(get_mtk(model_withemis))

--- a/ext/EmissionExt.jl
+++ b/ext/EmissionExt.jl
@@ -40,12 +40,12 @@ function register_couplings_ext()
         c = param_to_var(convert(ODESystem, c), :r_NO2, :r_NO, :r_FORM, :r_CH4, :r_CO, :r_SO2, :r_ISOP)
         ConnectorSystem([
             c.r_NO2 ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_NO ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_FORM ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_CH4 ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_CO ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_SO2 ~ e.mrggrid_withbeis_withrwc₊NO2 
-            c.r_ISOP ~ e.mrggrid_withbeis_withrwc₊NO2 
+            c.r_NO ~ e.mrggrid_withbeis_withrwc₊NO 
+            c.r_FORM ~ e.mrggrid_withbeis_withrwc₊FORM 
+            c.r_CH4 ~ e.mrggrid_withbeis_withrwc₊CH4 
+            c.r_CO ~ e.mrggrid_withbeis_withrwc₊CO 
+            c.r_SO2 ~ e.mrggrid_withbeis_withrwc₊SO2 
+            c.r_ISOP ~ e.mrggrid_withbeis_withrwc₊ISOP 
         ], c, e)
     end
     

--- a/src/GasChem.jl
+++ b/src/GasChem.jl
@@ -12,6 +12,7 @@ include("SuperFast.jl")
 include("Fast-JX.jl")
 include("geoschem_ratelaws.jl")
 include("geoschem_fullchem.jl")
+include("NeiEmission.jl")
 
 export register_couplings
 

--- a/src/NeiEmission.jl
+++ b/src/NeiEmission.jl
@@ -1,0 +1,63 @@
+export NeiEmissions
+
+"""
+This is a box model used to couple with the emis model (from the US National Emissions Inventory) to convert the emission rate to the ODE system of species shared in the SuperFast mechanism.
+Build NeiEmissions model to couple with SuperFast model and emis model
+# Example
+``` julia
+    using GasChem, EarthSciData    
+    @parameters t [unit = u"s"]
+    @parameters lat = 40 
+    @parameters lon = -97 
+    @parameters lev = 1
+    @parameters Δz = 60 [unit = u"m"]
+    emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", t, lon, lat, lev, Δz; dtype=Float64)
+
+    model = couple(SuperFast(t), NeiEmissions(t), emis)
+```
+"""
+function NeiEmissions(t)
+
+    emis_vars = Dict{String,Float64}(
+            "NO" => 30.01,
+            "NO2" => 46.0055,
+            "FORM" => 30.0260,
+            "CH4" => 16.0425,
+            "CO" => 28.0101,
+            "SO2" => 64.0638,
+            "ISOP" => 68.12,
+            )
+
+    @variables NO2(t) [unit = u"nmol/mol"]
+    @variables NO(t) [unit = u"nmol/mol"]
+    @variables FORM(t) [unit = u"nmol/mol"]
+    @variables CH4(t) [unit = u"nmol/mol"]
+    @variables CO(t) [unit = u"nmol/mol"]
+    @variables SO2(t) [unit = u"nmol/mol"]
+    @variables ISOP(t) [unit = u"nmol/mol"]
+
+    @parameters u_conv = 1 [unit = u"nmol/mol*m^3/kg"]
+    @parameters P = 101325 # Pa
+    @parameters Tep = 298.15 # K
+    @parameters RR = 8.314 # Pa*m3/(mol*K)
+    @parameters Δz2 = 60.0 # m  
+    @parameters r_NO2 [unit = u"kg/m^3/s"]
+    @parameters r_NO [unit = u"kg/m^3/s"]
+    @parameters r_FORM [unit = u"kg/m^3/s"]
+    @parameters r_CH4 [unit = u"kg/m^3/s"]
+    @parameters r_CO [unit = u"kg/m^3/s"]
+    @parameters r_SO2 [unit = u"kg/m^3/s"]
+    @parameters r_ISOP [unit = u"kg/m^3/s"]
+
+    eqs = [
+        Differential(t)(NO2) ~ r_NO2 * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["NO2"] * P),
+        Differential(t)(NO) ~ r_NO * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["NO"] * P),
+        Differential(t)(FORM) ~ r_FORM * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["FORM"] * P),
+        Differential(t)(CH4) ~ r_CH4 * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["CH4"] * P),
+        Differential(t)(CO) ~ r_CO * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["CO"] * P),
+        Differential(t)(SO2) ~ r_SO2 * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["SO2"] * P),
+        Differential(t)(ISOP) ~ r_ISOP * u_conv * 2000 / 2240 * 1e12 * RR * Tep / (emis_vars["ISOP"] * P)
+    ]
+
+    ODESystem(eqs, t, [NO2, NO, FORM, CH4, CO, SO2, ISOP], [r_NO2, r_NO, r_FORM, r_CH4, r_CO, r_SO2, r_ISOP, P, Tep, RR, Δz2, u_conv]; name=:new_emis)
+end

--- a/test/Emission_test.jl
+++ b/test/Emission_test.jl
@@ -10,12 +10,12 @@ using Test, Dates, ModelingToolkit, DifferentialEquations, EarthSciMLBase, Unitf
     @parameters Δz = 60 [unit = u"m"]
     emis = NEI2016MonthlyEmis("mrggrid_withbeis_withrwc", t, lon, lat, lev, Δz; dtype=Float64)
 
-    model_3way = couple(FastJX(t), SuperFast(t), emis)
+    model_3way = couple(FastJX(t), SuperFast(t), emis, NeiEmissions(t))
 
     sys = structural_simplify(get_mtk(model_3way))
     @test length(states(sys)) ≈ 18
 
     eqs = string(equations(sys))
-    wanteqs = ["Differential(t)(superfast₊CH2O(t)) ~ superfast₊NEI2016MonthlyEmis_mrggrid_withbeis_withrwc₊FORM(t)"]
+    wanteqs = ["Differential(t)(superfast₊ISOP(t)) ~ superfast₊new_emis_ddt_ISOPˍt(t)"]
     @test contains(string(eqs), wanteqs[1])
 end


### PR DESCRIPTION
Hi, Chris,

The variables in SuperFast(t), such as SO2(t), represent the concentration of SO2. However, the variables in the emis model, such as emis.mrggrid_withbeis_withrwc₊SO2, represent the emission rate of SO2. I used to directly couple the two models together with equations that equated these variables, which is incorrect.

To correct this, I created a new function NeiEmissions(t) under the /src file in the GasChem module, and defined the coupling logic as follows:

Variables in SuperFast(t) ~ Variables in NeiEmissions(t) [species: ppb]
Variables in emis ~ Parameters in NeiEmissions(t) [emission rate: ppb/s]

All source code, unit tests, and documentation have been updated.