### PR TITLE
Comprehensive Update Across All Modules Following GEOS-CHEM

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -30,7 +30,7 @@ function EarthSciMLBase.couple2(c::GasChem.SuperFastCoupler, e::EarthSciData.NEI
         c.NO2 => e.NO2 => uconv / MW_NO2,
         c.NO => e.NO => uconv / MW_NO,
         c.CH2O => e.FORM => uconv / MW_FORM,
-        c.CH4 => e.CH4 => uconv / MW_CH4,
+        #c.CH4 => e.CH4 => uconv / MW_CH4,
         c.CO => e.CO => uconv / MW_CO,
         c.SO2 => e.SO2 => uconv / MW_SO2,
         c.ISOP => e.ISOP => uconv / MW_ISOP,
@@ -39,6 +39,16 @@ end
 
 function EarthSciMLBase.couple2(c::GasChem.SuperFastCoupler, g::EarthSciData.GEOSFPCoupler)
     c, g = c.sys, g.sys
+
+    @constants(
+        MW_H2O = 18.015*10^-3, [unit = u"kg/mol", description="Water molar mass"],
+        MW_air = 28.97*10^-3, [unit = u"kg/mol", description = "Air molar mass"],
+        ppbpersecond = 1e9, [unit = u"ppb/s"],
+    )
+    uconv = MW_air/MW_H2O*ppbpersecond
+    operator_compose(convert(ODESystem, c), g, Dict(
+        c.H2O => g.I3₊QV => uconv,
+    ))
 
     c = param_to_var(c, :T, :P)
     ConnectorSystem([

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -30,8 +30,8 @@ function EarthSciMLBase.couple2(c::GasChem.SuperFastCoupler, e::EarthSciData.NEI
         c.NO2 => e.NO2 => uconv / MW_NO2,
         c.NO => e.NO => uconv / MW_NO,
         c.CH2O => e.FORM => uconv / MW_FORM,
-        #c.CH4 => e.CH4 => uconv / MW_CH4,
         c.CO => e.CO => uconv / MW_CO,
+        #c.SO2 => e.SULF => uconv / MW_SO2, #TODO Need to find a way to make c.SO2 => e.SULF + e.SO2 => uconv / MW_SO2
         c.SO2 => e.SO2 => uconv / MW_SO2,
         c.ISOP => e.ISOP => uconv / MW_ISOP,
     ))

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -131,6 +131,7 @@ end
 # get information about the type and units of the output.
 j_mean_H2O2(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
 j_mean_CH2Oa(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
+j_mean_CH2Ob(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
 j_mean_CH3OOH(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
 j_mean_NO2(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
 j_mean_o31D(t, lat, long, T::DynamicQuantities.Quantity) = 0.0u"s^-1"
@@ -139,6 +140,8 @@ j_mean_H2O2(t, lat, long, T) = j_mean(σ_H2O2_interp, ϕ_H2O2_jx, t, lat, long, 
 @register_symbolic j_mean_H2O2(t, lat, long, T)
 j_mean_CH2Oa(t, lat, long, T) = j_mean(σ_CH2Oa_interp, ϕ_CH2Oa_jx, t, lat, long, T)
 @register_symbolic j_mean_CH2Oa(t, lat, long, T)
+j_mean_CH2Ob(t, lat, long, T) = j_mean(σ_CH2Ob_interp, ϕ_CH2Ob_jx, t, lat, long, T)
+@register_symbolic j_mean_CH2Ob(t, lat, long, T)
 j_mean_CH3OOH(t, lat, long, T) = j_mean(σ_CH3OOH_interp, ϕ_CH3OOH_jx, t, lat, long, T)
 @register_symbolic j_mean_CH3OOH(t, lat, long, T)
 j_mean_NO2(t, lat, long, T) = j_mean(σ_NO2_interp, ϕ_NO2_jx, t, lat, long, T)
@@ -170,17 +173,17 @@ function FastJX(;name=:FastJX)
     @variables j_o31D(t) = 4.0 * 10.0^-3 [unit = u"s^-1"]
     @variables j_CH3OOH(t) = 8.9573 * 10.0^-6 [unit = u"s^-1"]
     @variables j_NO2(t) = 0.0149 [unit = u"s^-1"]
-    # TODO(JL): What's difference between the two photolysis reactions of CH2O, do we really need both? 
-    # (@variables j_CH2Ob(t) = 0.00014 [unit = u"s^-1"]) (j_CH2Ob ~ mean_J_CH2Ob(t,lat,T)*j_unit)
+    @variables j_CH2Ob(t) = 0.00014 [unit = u"s^-1"]
 
     eqs = [
         j_h2o2 ~ j_mean_H2O2(t, lat, long, T)
         j_CH2Oa ~ j_mean_CH2Oa(t, lat, long, T)
+        j_CH2Ob ~ j_mean_CH2Ob(t, lat, long, T)
         j_o31D ~ j_mean_o31D(t, lat, long, T)
         j_CH3OOH ~ j_mean_CH3OOH(t, lat, long, T)
         j_NO2 ~ j_mean_NO2(t, lat, long, T)
     ]
 
-    ODESystem(eqs, t, [j_h2o2, j_CH2Oa, j_o31D, j_CH3OOH, j_NO2], [lat, long, T]; name=name,
+    ODESystem(eqs, t, [j_h2o2, j_CH2Oa, j_CH2Ob, j_o31D, j_CH3OOH, j_NO2], [lat, long, T]; name=name,
         metadata=Dict(:coupletype => FastJXCoupler))
 end

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -175,13 +175,15 @@ function FastJX(;name=:FastJX)
     @variables j_NO2(t) = 0.0149 [unit = u"s^-1"]
     @variables j_CH2Ob(t) = 0.00014 [unit = u"s^-1"]
 
+    rate1(k) = k / 2.6875e10 #Convert the first reaction rate value, which corresponds to species with units of molec/cm³, to ppb.  1 ppb of a gas is roughly 2.6875e10 molec/cm3. (2.6875e10 = A/air_volume*1e-9)
+
     eqs = [
-        j_h2o2 ~ j_mean_H2O2(t, lat, long, T)
-        j_CH2Oa ~ j_mean_CH2Oa(t, lat, long, T)
-        j_CH2Ob ~ j_mean_CH2Ob(t, lat, long, T)
-        j_o31D ~ j_mean_o31D(t, lat, long, T)
-        j_CH3OOH ~ j_mean_CH3OOH(t, lat, long, T)
-        j_NO2 ~ j_mean_NO2(t, lat, long, T)
+        j_h2o2 ~ rate1(j_mean_H2O2(t, lat, long, T))
+        j_CH2Oa ~ rate1(j_mean_CH2Oa(t, lat, long, T))
+        j_CH2Ob ~ rate1(j_mean_CH2Ob(t, lat, long, T))
+        j_o31D ~ rate1(j_mean_o31D(t, lat, long, T))
+        j_CH3OOH ~ rate1(j_mean_CH3OOH(t, lat, long, T))
+        j_NO2 ~ rate1(j_mean_NO2(t, lat, long, T))
     ]
 
     ODESystem(eqs, t, [j_h2o2, j_CH2Oa, j_CH2Ob, j_o31D, j_CH3OOH, j_NO2], [lat, long, T]; name=name,

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -175,15 +175,13 @@ function FastJX(;name=:FastJX)
     @variables j_NO2(t) = 0.0149 [unit = u"s^-1"]
     @variables j_CH2Ob(t) = 0.00014 [unit = u"s^-1"]
 
-    rate1(k) = k / 2.6875e10 #Convert the first reaction rate value, which corresponds to species with units of molec/cm³, to ppb.  1 ppb of a gas is roughly 2.6875e10 molec/cm3. (2.6875e10 = A/air_volume*1e-9)
-
     eqs = [
-        j_h2o2 ~ rate1(j_mean_H2O2(t, lat, long, T))
-        j_CH2Oa ~ rate1(j_mean_CH2Oa(t, lat, long, T))
-        j_CH2Ob ~ rate1(j_mean_CH2Ob(t, lat, long, T))
-        j_o31D ~ rate1(j_mean_o31D(t, lat, long, T))
-        j_CH3OOH ~ rate1(j_mean_CH3OOH(t, lat, long, T))
-        j_NO2 ~ rate1(j_mean_NO2(t, lat, long, T))
+        j_h2o2 ~ j_mean_H2O2(t, lat, long, T)
+        j_CH2Oa ~ j_mean_CH2Oa(t, lat, long, T)
+        j_CH2Ob ~ j_mean_CH2Ob(t, lat, long, T)
+        j_o31D ~ j_mean_o31D(t, lat, long, T)
+        j_CH3OOH ~ j_mean_CH3OOH(t, lat, long, T)
+        j_NO2 ~ j_mean_NO2(t, lat, long, T)
     ]
 
     ODESystem(eqs, t, [j_h2o2, j_CH2Oa, j_CH2Ob, j_o31D, j_CH3OOH, j_NO2], [lat, long, T]; name=name,

--- a/src/GasChem.jl
+++ b/src/GasChem.jl
@@ -11,9 +11,9 @@ using ModelingToolkit:t
 
 @register_unit ppb 1
 
-include("SuperFast.jl")
 include("geoschem_ratelaws.jl")
 include("geoschem_fullchem.jl")
+include("SuperFast.jl")
 include("Fast-JX.jl")
 include("fastjx_couplings.jl")
 

--- a/src/GasChem.jl
+++ b/src/GasChem.jl
@@ -9,7 +9,10 @@ using StaticArrays
 using Interpolations
 using ModelingToolkit:t
 
-@register_unit ppb 1
+@register_unit molec 1
+@register_unit mol_air 1u"mol"
+@register_unit ppb 1u"mol/mol_air"
+#TODO if @register_unit ppb 1e-9u"mol/mol_air" if @register_unit ppb 1e-9u"mol/mol_air", though it's physically correct, but this will result ModelingToolkit.ValidationError when coupling different models.
 
 include("geoschem_ratelaws.jl")
 include("geoschem_fullchem.jl")

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -25,6 +25,7 @@ plot(sol)
 ```
 """
 function SuperFast(;name=:SuperFast, rxn_sys=false)
+    @constants A = 6.02e23 [unit = u"molec/mol", description = "Avogadro's number"]
     params = @parameters(
         jO31D = 4.0 * 10.0^-3, [unit = u"s^-1"],
         jH2O2 = 1.0097 * 10.0^-5, [unit = u"s^-1"],
@@ -32,55 +33,58 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         jCH2Oa = 0.00014, [unit = u"s^-1"],
         jCH2Ob = 0.00014, [unit = u"s^-1"],
         jCH3OOH = 8.9573 * 10.0^-6, [unit = u"s^-1"],
-        k1 = 1.7e-12, [unit = u"(s*ppb)^-1"], T1 = -940, [unit = u"K"],
-        k2 = 1.0e-14, [unit = u"(s*ppb)^-1"], T2 = -490, [unit = u"K"],
-        k3 = 4.8e-11, [unit = u"(s*ppb)^-1"], T3 = 250, [unit = u"K"],
-        k4 = 3.0e-12, [unit = u"(s*ppb)^-1"], T4 = -1500, [unit = u"K"],
-        k5 = 3.5e-12, [unit = u"(s*ppb)^-1"], T5 = 250, [unit = u"K"],
-        k6 = 2.45e-12, [unit = u"(s*ppb)^-1"], T6 = -1775, [unit = u"K"],
-        k7 = 5.5e-12, [unit = u"(s*ppb)^-1"], T7 = 125, [unit = u"K"],
-        k8 = 4.1e-13, [unit = u"(s*ppb)^-1"], T8 = 750, [unit = u"K"],
-        k9 = 2.7e-12, [unit = u"(s*ppb)^-1"], T9 = 200, [unit = u"K"],
-        k11 = 2.8e-12, [unit = u"(s*ppb)^-1"], T11 = 300, [unit = u"K"],
-        k12 = 9.5e-14 / 10, [unit = u"s^-1*(ppb)^-19"], T12 = 390, [unit = u"K"],
-        k13 = 1.1e-11, [unit = u"(s*ppb)^-1"], T13 = -240, [unit = u"K"],
-        k14 = 2.7e-11, [unit = u"(s*ppb)^-1"], T14 = 390, [unit = u"K"],
-        k15 = 2.7e-11 / 2, [unit = u"s^-1*(ppb)^-3"], T15 = 390, [unit = u"K"],
-        k16 = 5.59e-15, [unit = u"(s*ppb)^-1"], T16 = -1814, [unit = u"K"],
-        k17 = 3.0e-13, [unit = u"(s*ppb)^-1"], T17 = 460, [unit = u"K"],
-        k18 = 1.8e-12, [unit = u"(s*ppb)^-1"],
-        k19 = 1.5e-13, [unit = u"(s*ppb)^-1"],
+        k1 = 1.7e-12, [unit = u"cm^3/molec/s"], T1 = -940, [unit = u"K"],
+        k2 = 1.0e-14, [unit = u"cm^3/molec/s"], T2 = -490, [unit = u"K"],
+        k3 = 4.8e-11, [unit = u"cm^3/molec/s"], T3 = 250, [unit = u"K"],
+        k4 = 3.0e-12, [unit = u"cm^3/molec/s"], T4 = -1500, [unit = u"K"],
+        k5 = 3.5e-12, [unit = u"cm^3/molec/s"], T5 = 250, [unit = u"K"],
+        k6 = 2.45e-12, [unit = u"cm^3/molec/s"], T6 = -1775, [unit = u"K"],
+        k7 = 5.5e-12, [unit = u"cm^3/molec/s"], T7 = 125, [unit = u"K"],
+        k8 = 4.1e-13, [unit = u"cm^3/molec/s"], T8 = 750, [unit = u"K"],
+        k9 = 2.7e-12, [unit = u"cm^3/molec/s"], T9 = 200, [unit = u"K"],
+        k11 = 2.8e-12, [unit = u"cm^3/molec/s"], T11 = 300, [unit = u"K"],
+        k12 = 9.5e-14 / 10, [unit = u"s^-1*(molec/cm^3)^-19"], T12 = 390, [unit = u"K"],
+        k13 = 1.1e-11, [unit = u"cm^3/molec/s"], T13 = -240, [unit = u"K"],
+        k14 = 2.7e-11, [unit = u"cm^3/molec/s"], T14 = 390, [unit = u"K"],
+        k15 = 2.7e-11 / 2, [unit = u"s^-1*(molec/cm^3)^-3"], T15 = 390, [unit = u"K"],
+        k16 = 5.59e-15, [unit = u"cm^3/molec/s"], T16 = -1814, [unit = u"K"],
+        k17 = 3.0e-13, [unit = u"cm^3/molec/s"], T17 = 460, [unit = u"K"],
+        k18 = 1.8e-12, [unit = u"cm^3/molec/s"],
+        k19 = 1.5e-13, [unit = u"cm^3/molec/s"],
         T18 = 89, [unit = u"K"],
         K_300 = 300, [unit = u"K"],
-        k_unit = 1, [unit = u"(s*ppb)^-1"],
+        k_unit = 1, [unit = u"cm^3/molec/s"],
         T = 280.0, [unit = u"K", description = "Temperature"],
         P = 101325, [unit = u"Pa", description = "Pressure (not directly used)"],
         num_density = 2.7e19, [description = "Number density of air (The units should be molecules/cm^3 but the equations here treat it as unitless)."],
-        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = u"ppb"],
-        CH4 = 1700.0, [isconstantspecies=true, unit = u"ppb"],
+        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = us"ppb"],
+        CH4 = 1700.0, [isconstantspecies=true, unit = us"ppb"],
+        air_volume = 22400, [unit = u"cm^3/mol_air"],
+        ppb_unit = 1e-9, [unit = us"ppb", description = "Convert from mol/mol_air to ppb"],
     )
 
     species = @species(
-        O3(t) = 10.0, [unit = u"ppb"],
-        O1d(t) = 0.00001, [unit = u"ppb"],
-        OH(t) = 10.0, [unit = u"ppb"],
-        HO2(t) = 10.0, [unit = u"ppb"],
-        H2O(t) = 450.0, [unit = u"ppb"],
-        NO(t) = 0.0, [unit = u"ppb"],
-        NO2(t) = 10.0, [unit = u"ppb"],
-        CH3O2(t) = 0.01, [unit = u"ppb"],
-        CH2O(t) = 0.15, [unit = u"ppb"],
-        CO(t) = 275.0, [unit = u"ppb"],
-        CH3OOH(t) = 1.6, [unit = u"ppb"],
-        DMS(t) = 50, [unit = u"ppb"],
-        SO2(t) = 2.0, [unit = u"ppb"],
-        ISOP(t) = 0.15, [unit = u"ppb"],
-        H2O2(t) = 2.34, [unit = u"ppb"],
-        HNO3(t) = 10, [unit = u"ppb"],
+        O3(t) = 10.0, [unit = us"ppb"],
+        O1d(t) = 0.00001, [unit = us"ppb"],
+        OH(t) = 10.0, [unit = us"ppb"],
+        HO2(t) = 10.0, [unit = us"ppb"],
+        H2O(t) = 450.0, [unit = us"ppb"],
+        NO(t) = 0.0, [unit = us"ppb"],
+        NO2(t) = 10.0, [unit = us"ppb"],
+        CH3O2(t) = 0.01, [unit = us"ppb"],
+        CH2O(t) = 0.15, [unit = us"ppb"],
+        CO(t) = 275.0, [unit = us"ppb"],
+        CH3OOH(t) = 1.6, [unit = us"ppb"],
+        DMS(t) = 50, [unit = us"ppb"],
+        SO2(t) = 2.0, [unit = us"ppb"],
+        ISOP(t) = 0.15, [unit = us"ppb"],
+        H2O2(t) = 2.34, [unit = us"ppb"],
+        HNO3(t) = 10, [unit = us"ppb"],
     )
 
-    @constants P_hack = 1.0e20, [unit = u"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
-    rate(k, Tc) = k * exp(Tc / T)
+    @constants P_hack = 1.0e20, [unit = us"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
+    rate2(k, Tc) = k * exp(Tc / T) * A / air_volume * ppb_unit #Convert the second reaction rate value, which corresponds to species with units of molec/cm³, to ppb.
+    rate1(k) = k / 2.6875e10 #Convert the first reaction rate value, which corresponds to species with units of molec/cm³, to ppb.  1 ppb of a gas is roughly 2.6875e10 molec/cm3. (2.6875e10 = A/air_volume*1e-9)
 
     function arr3(T, num_density, a1, b1, c1, a2, b2, c2, fv)
         arr(T,a0,b0,c0) = a0 * exp(c0 / T) * (K_300 / T)^b0
@@ -92,63 +96,63 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         blog = log10(xyrat)
         fexp = 1.0 / (1.0 + (blog * blog))
         k = rlow * (fv^fexp) / (1.0 + xyrat)
-        return k*k_unit
+        return k*k_unit* A / air_volume * ppb_unit
     end
 
     # Create reaction system, ignoring aqueous chemistry.
     rxs = [
         #O3 + OH --> HO2 + O2
-        Reaction(rate(k1, T1), [O3, OH], [HO2, O2], [1, 1], [1, 1])
+        Reaction(rate2(k1, T1), [O3, OH], [HO2, O2], [1, 1], [1, 1])
         #HO2 + O3 --> 2O2 + OH
-        Reaction(rate(k2, T2), [HO2, O3], [O2, OH], [1, 1], [2, 1])
+        Reaction(rate2(k2, T2), [HO2, O3], [O2, OH], [1, 1], [2, 1])
         #HO2 + OH --> H2O + O2
-        Reaction(rate(k3, T3), [HO2, OH], [HO2, O2], [1, 1], [1, 1])
+        Reaction(rate2(k3, T3), [HO2, OH], [HO2, O2], [1, 1], [1, 1])
         #NO + O3 --> NO2 + O2
-        Reaction(rate(k4, T4), [NO, O3], [NO2, O2], [1, 1], [1, 1])
+        Reaction(rate2(k4, T4), [NO, O3], [NO2, O2], [1, 1], [1, 1])
         #NO2 + OH {+M} --> HNO3 {+M}
         Reaction(arr3(T, num_density, 1.8e30, 3.0, 0.0, 2.8e-11, 0.0, 0.0, 0.6), [NO2, OH], [HNO3])
         #HO2 + NO --> NO2 + OH 
-        Reaction(rate(k5, T5), [HO2, NO], [NO2, OH], [1, 1], [1, 1])
+        Reaction(rate2(k5, T5), [HO2, NO], [NO2, OH], [1, 1], [1, 1])
         #CH4 + OH --> CH3O2 + H2O
-        Reaction(rate(k6, T6), [CH4, OH], [CH3O2, H2O], [1, 1], [1, 1])
+        Reaction(rate2(k6, T6), [CH4, OH], [CH3O2, H2O], [1, 1], [1, 1])
         #CH2O + OH --> CO + H2O + HO2
-        Reaction(rate(k7, T7), [CH2O, OH], [CO, H2O, HO2], [1, 1], [1, 1, 1])
+        Reaction(rate2(k7, T7), [CH2O, OH], [CO, H2O, HO2], [1, 1], [1, 1, 1])
         #CH3O2 + HO2 --> CH3OOH + O2
-        Reaction(rate(k8, T8), [CH3O2, HO2], [CH3OOH, O2], [1, 1], [1, 1])
+        Reaction(rate2(k8, T8), [CH3O2, HO2], [CH3OOH, O2], [1, 1], [1, 1])
         #CH3OOH + OH --> CH3O2 + H2O
-        Reaction(rate(k9, T9), [CH3OOH, OH], [CH3O2, H2O], [1, 1], [1, 1])
+        Reaction(rate2(k9, T9), [CH3OOH, OH], [CH3O2, H2O], [1, 1], [1, 1])
         #CH3O2 + NO --> CH2O + HO2 + NO2    
-        Reaction(rate(k11, T11), [CH3O2, NO], [CH2O, HO2, NO2], [1, 1], [1, 1, 1])
+        Reaction(rate2(k11, T11), [CH3O2, NO], [CH2O, HO2, NO2], [1, 1], [1, 1, 1])
         #10CH3O2 + 10CH3O2 --> 20CH2O + 8HO2
-        Reaction(rate(k12, T12), [CH3O2], [CH2O, H2O], [20], [20, 8])
+        Reaction(rate2(k12, T12)*(A / air_volume * ppb_unit)^18, [CH3O2], [CH2O, H2O], [20], [20, 8])
         #DMS + OH --> SO2
-        Reaction(rate(k13, T13), [DMS, OH], [SO2], [1, 1], [1])
+        Reaction(rate2(k13, T13), [DMS, OH], [SO2], [1, 1], [1])
         #ISOP +OH --> 2CH3O2
-        Reaction(rate(k14, T14), [ISOP, OH], [CH3O2], [1, 1], [2])
+        Reaction(rate2(k14, T14), [ISOP, OH], [CH3O2], [1, 1], [2])
         #2ISOP + 2OH --> 2ISOP + OH
-        Reaction(rate(k15, T15), [ISOP, OH], [ISOP, OH], [2, 2], [2, 1])
+        Reaction(rate2(k15, T15)*(A / air_volume * ppb_unit)^2, [ISOP, OH], [ISOP, OH], [2, 2], [2, 1])
         #ISOP + O3 --> 0.87CH2O + 1.86CH3O2 + 0.06HO2 + 0.05CO
-        Reaction(rate(k16, T16), [ISOP, O3], [CH2O, CH3O2, HO2, CO], [1, 1.0], [0.87, 1.86, 0.06, 0.05])
+        Reaction(rate2(k16, T16), [ISOP, O3], [CH2O, CH3O2, HO2, CO], [1, 1.0], [0.87, 1.86, 0.06, 0.05])
         #O3 -> O2 + O(1D)
-        Reaction(jO31D * 10^(-21), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
+        Reaction(rate1(jO31D * 10^(-21)), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
         #O(1D) + H2O -> 2OH
-        Reaction(1.45*10^-10*exp(T18/T)*k_unit, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
+        Reaction(1.45*10^-10*exp(T18/T)*k_unit*A/air_volume*ppb_unit, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
         #H2O2 --> 2OH
-        Reaction(jH2O2, [H2O2], [OH], [1], [2])
+        Reaction(rate1(jH2O2), [H2O2], [OH], [1], [2])
         #NO2 --> NO + O3
-        Reaction(jNO2, [NO2], [NO, O3], [1], [1, 1])
+        Reaction(rate1(jNO2), [NO2], [NO, O3], [1], [1, 1])
         #CH2O --> CO + 2HO2
-        Reaction(jCH2Oa, [CH2O], [CO, HO2], [1], [1, 2])
+        Reaction(rate1(jCH2Oa), [CH2O], [CO, HO2], [1], [1, 2])
         #CH2O --> CO
-        Reaction(jCH2Ob, [CH2O], [CO], [1], [1])
+        Reaction(rate1(jCH2Ob), [CH2O], [CO], [1], [1])
         #CH3OOH --> CH2O + HO2 + OH
-        Reaction(jCH3OOH, [CH3OOH], [CH2O, HO2, OH], [1], [1, 1, 1])
+        Reaction(rate1(jCH3OOH), [CH3OOH], [CH2O, HO2, OH], [1], [1, 1, 1])
         #HO2 + HO2 = H2O2 + O2
-        Reaction(rate(k17, T17), [HO2], [H2O2, O2], [2], [1, 1])
+        Reaction(rate2(k17, T17), [HO2], [H2O2, O2], [2], [1, 1])
         #OH + H2O2 = H2O + HO2
-        Reaction(k18, [OH, H2O2], [H2O, HO2], [1, 1], [1, 1])
+        Reaction(k18* A / air_volume * ppb_unit, [OH, H2O2], [H2O, HO2], [1, 1], [1, 1])
         #OH + CO = HO2
-        Reaction(k19 + P/P_hack, [OH, CO], [HO2], [1, 1], [1])
+        Reaction(k19* A / air_volume * ppb_unit + P/P_hack, [OH, CO], [HO2], [1, 1], [1])
         # FIXME(CT): Currently adding P*1e-20 to avoid pressure getting dropped from the model, so we can use it during coupling (for example, during emissions unit conversion).
     ]
     # We set `combinatoric_ratelaws=false` because we are modeling macroscopic rather than microscopic behavior. 
@@ -160,3 +164,4 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
     end
     convert(ODESystem, complete(rxns); metadata=Dict(:coupletype => SuperFastCoupler))
 end
+

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -51,7 +51,7 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         k17 = 3.0e-13, [unit = u"cm^3/molec/s"], T17 = 460, [unit = u"K"],
         k18 = 1.8e-12, [unit = u"cm^3/molec/s"],
         k19 = 1.5e-13, [unit = u"cm^3/molec/s"],
-        ko1d = 1.545e-10, [unit = u"cm^3/molec/s"], To1d = 89, [unit = u"K"],
+        ko1d = 1.45e-10, [unit = u"cm^3/molec/s"], To1d = 89, [unit = u"K"],
         K_300 = 300, [unit = u"K"],
         k_unit = 1, [unit = u"cm^3/molec/s"],
         T = 280.0, [unit = u"K", description = "Temperature"],

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -27,12 +27,12 @@ plot(sol)
 function SuperFast(;name=:SuperFast, rxn_sys=false)
     @constants A = 6.02e23 [unit = u"molec/mol", description = "Avogadro's number"]
     params = @parameters(
-        jO31D = 4.0 * 10.0^-3, [unit = u"s^-1"],
-        jH2O2 = 1.0097 * 10.0^-5, [unit = u"s^-1"],
+        jO31D = 4.0e-3, [unit = u"s^-1"],
+        jH2O2 = 1.0097e-5, [unit = u"s^-1"],
         jNO2 = 0.0149, [unit = u"s^-1"],
         jCH2Oa = 0.00014, [unit = u"s^-1"],
         jCH2Ob = 0.00014, [unit = u"s^-1"],
-        jCH3OOH = 8.9573 * 10.0^-6, [unit = u"s^-1"],
+        jCH3OOH = 8.9573e-6, [unit = u"s^-1"],
         k1 = 1.7e-12, [unit = u"cm^3/molec/s"], T1 = -940, [unit = u"K"],
         k2 = 1.0e-14, [unit = u"cm^3/molec/s"], T2 = -490, [unit = u"K"],
         k3 = 4.8e-11, [unit = u"cm^3/molec/s"], T3 = 250, [unit = u"K"],
@@ -43,21 +43,21 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         k8 = 4.1e-13, [unit = u"cm^3/molec/s"], T8 = 750, [unit = u"K"],
         k9 = 2.7e-12, [unit = u"cm^3/molec/s"], T9 = 200, [unit = u"K"],
         k11 = 2.8e-12, [unit = u"cm^3/molec/s"], T11 = 300, [unit = u"K"],
-        k12 = 9.5e-14 / 10, [unit = u"s^-1*(molec/cm^3)^-19"], T12 = 390, [unit = u"K"],
+        k12 = 9.5e-14, [unit = u"cm^3/molec/s"], T12 = 390, [unit = u"K"],
         k13 = 1.1e-11, [unit = u"cm^3/molec/s"], T13 = -240, [unit = u"K"],
         k14 = 2.7e-11, [unit = u"cm^3/molec/s"], T14 = 390, [unit = u"K"],
-        k15 = 2.7e-11 / 2, [unit = u"s^-1*(molec/cm^3)^-3"], T15 = 390, [unit = u"K"],
+        k15 = 2.7e-11, [unit = u"cm^3/molec/s"], T15 = 390, [unit = u"K"],
         k16 = 5.59e-15, [unit = u"cm^3/molec/s"], T16 = -1814, [unit = u"K"],
         k17 = 3.0e-13, [unit = u"cm^3/molec/s"], T17 = 460, [unit = u"K"],
         k18 = 1.8e-12, [unit = u"cm^3/molec/s"],
         k19 = 1.5e-13, [unit = u"cm^3/molec/s"],
-        T18 = 89, [unit = u"K"],
+        ko1d = 1.545e-10, [unit = u"cm^3/molec/s"], To1d = 89, [unit = u"K"],
         K_300 = 300, [unit = u"K"],
         k_unit = 1, [unit = u"cm^3/molec/s"],
         T = 280.0, [unit = u"K", description = "Temperature"],
         P = 101325, [unit = u"Pa", description = "Pressure (not directly used)"],
         num_density = 2.7e19, [description = "Number density of air (The units should be molecules/cm^3 but the equations here treat it as unitless)."],
-        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = u"ppb"],
+        O2 = 2.1e8, [isconstantspecies=true,unit = u"ppb"],
         CH4 = 1700.0, [isconstantspecies=true, unit = u"ppb"],
         ppb_unit = 1e-9, [unit = u"ppb", description = "Convert from mol/mol_air to ppb"],
     )
@@ -122,20 +122,20 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         Reaction(rate2(k9, T9), [CH3OOH, OH], [CH3O2, H2O], [1, 1], [1, 1])
         #CH3O2 + NO --> CH2O + HO2 + NO2    
         Reaction(rate2(k11, T11), [CH3O2, NO], [CH2O, HO2, NO2], [1, 1], [1, 1, 1])
-        #10CH3O2 + 10CH3O2 --> 20CH2O + 8HO2
-        Reaction(rate2(k12, T12)*(A / air_volume * ppb_unit)^18, [CH3O2], [CH2O, H2O], [20], [20, 8])
+        #CH3O2 + CH3O2 --> 2CH2O + 0.8HO2
+        Reaction(rate2(k12, T12), [CH3O2], [CH2O, H2O], [2], [2, 0.8])
         #DMS + OH --> SO2
         Reaction(rate2(k13, T13), [DMS, OH], [SO2], [1, 1], [1])
         #ISOP +OH --> 2CH3O2
         Reaction(rate2(k14, T14), [ISOP, OH], [CH3O2], [1, 1], [2])
-        #2ISOP + 2OH --> 2ISOP + OH
-        Reaction(rate2(k15, T15)*(A / air_volume * ppb_unit)^2, [ISOP, OH], [ISOP, OH], [2, 2], [2, 1])
+        #ISOP + OH --> ISOP + 0.5OH
+        Reaction(rate2(k15, T15), [ISOP, OH], [ISOP, OH], [1, 1], [1, 0.5])
         #ISOP + O3 --> 0.87CH2O + 1.86CH3O2 + 0.06HO2 + 0.05CO
         Reaction(rate2(k16, T16), [ISOP, O3], [CH2O, CH3O2, HO2, CO], [1, 1.0], [0.87, 1.86, 0.06, 0.05])
         #O3 -> O2 + O(1D)
         Reaction(jO31D * 10^(-21), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
         #O(1D) + H2O -> 2OH
-        Reaction(1.45*10^-10*exp(T18/T)*k_unit*A/air_volume*ppb_unit, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
+        Reaction(rate2(ko1d, To1d), [O1d, H2O], [OH], [1, 1], [2]) 
         #H2O2 --> 2OH
         Reaction(jH2O2, [H2O2], [OH], [1], [2])
         #NO2 --> NO + O3

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -27,11 +27,10 @@ plot(sol)
 function SuperFast(;name=:SuperFast, rxn_sys=false)
     params = @parameters(
         jO31D = 4.0 * 10.0^-3, [unit = u"s^-1"],
-        j2OH = 2.2 * 10.0^-10, [unit = u"(s*ppb)^-1"],
         jH2O2 = 1.0097 * 10.0^-5, [unit = u"s^-1"],
         jNO2 = 0.0149, [unit = u"s^-1"],
         jCH2Oa = 0.00014, [unit = u"s^-1"],
-        # TODO(JL): What's difference between the two photolysis reactions of CH2O, do we really need both? (@variables jCH20b(t) = 0.00014 [unit = u"s^-1"])
+        jCH2Ob = 0.00014, [unit = u"s^-1"],
         jCH3OOH = 8.9573 * 10.0^-6, [unit = u"s^-1"],
         k1 = 1.7e-12, [unit = u"(s*ppb)^-1"], T1 = -940, [unit = u"K"],
         k2 = 1.0e-14, [unit = u"(s*ppb)^-1"], T2 = -490, [unit = u"K"],
@@ -42,7 +41,6 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         k7 = 5.5e-12, [unit = u"(s*ppb)^-1"], T7 = 125, [unit = u"K"],
         k8 = 4.1e-13, [unit = u"(s*ppb)^-1"], T8 = 750, [unit = u"K"],
         k9 = 2.7e-12, [unit = u"(s*ppb)^-1"], T9 = 200, [unit = u"K"],
-        k10 = 1.1e-12, [unit = u"(s*ppb)^-1"], T10 = 200, [unit = u"K"],
         k11 = 2.8e-12, [unit = u"(s*ppb)^-1"], T11 = 300, [unit = u"K"],
         k12 = 9.5e-14 / 10, [unit = u"s^-1*(ppb)^-19"], T12 = 390, [unit = u"K"],
         k13 = 1.1e-11, [unit = u"(s*ppb)^-1"], T13 = -240, [unit = u"K"],
@@ -52,8 +50,14 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         k17 = 3.0e-13, [unit = u"(s*ppb)^-1"], T17 = 460, [unit = u"K"],
         k18 = 1.8e-12, [unit = u"(s*ppb)^-1"],
         k19 = 1.5e-13, [unit = u"(s*ppb)^-1"],
+        T18 = 89, [unit = u"K"],
+        K_300 = 300, [unit = u"K"],
+        k_unit = 1, [unit = u"(s*ppb)^-1"],
         T = 280.0, [unit = u"K", description = "Temperature"],
         P = 101325, [unit = u"Pa", description = "Pressure (not directly used)"],
+        num_density = 2.7e19, [description = "Number density of air (The units should be molecules/cm^3 but the equations here treat it as unitless)."],
+        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = u"ppb"],
+        CH4 = 1700.0, [isconstantspecies=true, unit = u"ppb"],
     )
 
     species = @species(
@@ -61,25 +65,35 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         O1d(t) = 0.00001, [unit = u"ppb"],
         OH(t) = 10.0, [unit = u"ppb"],
         HO2(t) = 10.0, [unit = u"ppb"],
-        O2(t) = 2.1 * (10.0^8), [unit = u"ppb"],
         H2O(t) = 450.0, [unit = u"ppb"],
         NO(t) = 0.0, [unit = u"ppb"],
         NO2(t) = 10.0, [unit = u"ppb"],
-        CH4(t) = 1700.0, [unit = u"ppb"],
         CH3O2(t) = 0.01, [unit = u"ppb"],
         CH2O(t) = 0.15, [unit = u"ppb"],
         CO(t) = 275.0, [unit = u"ppb"],
         CH3OOH(t) = 1.6, [unit = u"ppb"],
-        CH3O(t) = 0.0, [unit = u"ppb"],
         DMS(t) = 50, [unit = u"ppb"],
         SO2(t) = 2.0, [unit = u"ppb"],
         ISOP(t) = 0.15, [unit = u"ppb"],
         H2O2(t) = 2.34, [unit = u"ppb"],
+        HNO3(t) = 10, [unit = u"ppb"],
     )
-    @constants P_hack = 1.0e20, [unit = u"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
 
-    c = 2.46e10 # TODO(JL): What is this constant?
-    rate(k, Tc) = k * exp(Tc / T) * c
+    @constants P_hack = 1.0e20, [unit = u"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
+    rate(k, Tc) = k * exp(Tc / T)
+
+    function arr3(T, num_density, a1, b1, c1, a2, b2, c2, fv)
+        arr(T,a0,b0,c0) = a0 * exp(c0 / T) * (K_300 / T)^b0
+        alow = arr(T, a1, b1, c1)
+        ahigh = arr(T, a2, b2, c2)
+        rlow = alow * num_density
+        rhigh = ahigh
+        xyrat = rlow / rhigh
+        blog = log10(xyrat)
+        fexp = 1.0 / (1.0 + (blog * blog))
+        k = rlow * (fv^fexp) / (1.0 + xyrat)
+        return k*k_unit
+    end
 
     # Create reaction system, ignoring aqueous chemistry.
     rxs = [
@@ -91,6 +105,8 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         Reaction(rate(k3, T3), [HO2, OH], [HO2, O2], [1, 1], [1, 1])
         #NO + O3 --> NO2 + O2
         Reaction(rate(k4, T4), [NO, O3], [NO2, O2], [1, 1], [1, 1])
+        #NO2 + OH {+M} --> HNO3 {+M}
+        Reaction(arr3(T, num_density, 1.8e30, 3.0, 0.0, 2.8e-11, 0.0, 0.0, 0.6), [NO2, OH], [HNO3])
         #HO2 + NO --> NO2 + OH 
         Reaction(rate(k5, T5), [HO2, NO], [NO2, OH], [1, 1], [1, 1])
         #CH4 + OH --> CH3O2 + H2O
@@ -101,8 +117,6 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         Reaction(rate(k8, T8), [CH3O2, HO2], [CH3OOH, O2], [1, 1], [1, 1])
         #CH3OOH + OH --> CH3O2 + H2O
         Reaction(rate(k9, T9), [CH3OOH, OH], [CH3O2, H2O], [1, 1], [1, 1])
-        #CH3OOH + OH --> CH3O + H2O + OH
-        Reaction(rate(k10, T10), [CH3OOH, OH], [CH3O, H2O, OH], [1, 1], [1, 1, 1])
         #CH3O2 + NO --> CH2O + HO2 + NO2    
         Reaction(rate(k11, T11), [CH3O2, NO], [CH2O, HO2, NO2], [1, 1], [1, 1, 1])
         #10CH3O2 + 10CH3O2 --> 20CH2O + 8HO2
@@ -118,7 +132,7 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         #O3 -> O2 + O(1D)
         Reaction(jO31D * 10^(-21), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
         #O(1D) + H2O -> 2OH
-        Reaction(j2OH * 100, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
+        Reaction(1.45*10^-10*exp(T18/T)*k_unit, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
         #H2O2 --> 2OH
         Reaction(jH2O2, [H2O2], [OH], [1], [2])
         #NO2 --> NO + O3
@@ -126,15 +140,15 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         #CH2O --> CO + 2HO2
         Reaction(jCH2Oa, [CH2O], [CO, HO2], [1], [1, 2])
         #CH2O --> CO
-        # TODO(JL): What's difference between the two photolysis reactions of CH2O, do we really need both? (Reaction(jCH20b, [CH2O], [CO], [1], [1]))
+        Reaction(jCH2Ob, [CH2O], [CO], [1], [1])
         #CH3OOH --> CH2O + HO2 + OH
         Reaction(jCH3OOH, [CH3OOH], [CH2O, HO2, OH], [1], [1, 1, 1])
         #HO2 + HO2 = H2O2 + O2
         Reaction(rate(k17, T17), [HO2], [H2O2, O2], [2], [1, 1])
         #OH + H2O2 = H2O + HO2
-        Reaction(k18 * c, [OH, H2O2], [H2O, HO2], [1, 1], [1, 1])
+        Reaction(k18, [OH, H2O2], [H2O, HO2], [1, 1], [1, 1])
         #OH + CO = HO2
-        Reaction(k19 * c + P/P_hack, [OH, CO], [HO2], [1, 1], [1])
+        Reaction(k19 + P/P_hack, [OH, CO], [HO2], [1, 1], [1])
         # FIXME(CT): Currently adding P*1e-20 to avoid pressure getting dropped from the model, so we can use it during coupling (for example, during emissions unit conversion).
     ]
     # We set `combinatoric_ratelaws=false` because we are modeling macroscopic rather than microscopic behavior. 

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -84,7 +84,6 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
 
     @constants P_hack = 1.0e20, [unit = us"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
     rate2(k, Tc) = k * exp(Tc / T) * A / air_volume * ppb_unit #Convert the second reaction rate value, which corresponds to species with units of molec/cm³, to ppb.
-    rate1(k) = k / 2.6875e10 #Convert the first reaction rate value, which corresponds to species with units of molec/cm³, to ppb.  1 ppb of a gas is roughly 2.6875e10 molec/cm3. (2.6875e10 = A/air_volume*1e-9)
 
     function arr3(T, num_density, a1, b1, c1, a2, b2, c2, fv)
         arr(T,a0,b0,c0) = a0 * exp(c0 / T) * (K_300 / T)^b0
@@ -134,19 +133,19 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         #ISOP + O3 --> 0.87CH2O + 1.86CH3O2 + 0.06HO2 + 0.05CO
         Reaction(rate2(k16, T16), [ISOP, O3], [CH2O, CH3O2, HO2, CO], [1, 1.0], [0.87, 1.86, 0.06, 0.05])
         #O3 -> O2 + O(1D)
-        Reaction(rate1(jO31D * 10^(-21)), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
+        Reaction(jO31D * 10^(-21), [O3], [O1d, O2], [1], [1, 1]) # TODO(JL): Is 10^(-20) a reasonable value?
         #O(1D) + H2O -> 2OH
         Reaction(1.45*10^-10*exp(T18/T)*k_unit*A/air_volume*ppb_unit, [O1d, H2O], [OH], [1, 1], [2]) # TODO(CT): Why is the rate multiplied by 10^2?
         #H2O2 --> 2OH
-        Reaction(rate1(jH2O2), [H2O2], [OH], [1], [2])
+        Reaction(jH2O2, [H2O2], [OH], [1], [2])
         #NO2 --> NO + O3
-        Reaction(rate1(jNO2), [NO2], [NO, O3], [1], [1, 1])
+        Reaction(jNO2, [NO2], [NO, O3], [1], [1, 1])
         #CH2O --> CO + 2HO2
-        Reaction(rate1(jCH2Oa), [CH2O], [CO, HO2], [1], [1, 2])
+        Reaction(jCH2Oa, [CH2O], [CO, HO2], [1], [1, 2])
         #CH2O --> CO
-        Reaction(rate1(jCH2Ob), [CH2O], [CO], [1], [1])
+        Reaction(jCH2Ob, [CH2O], [CO], [1], [1])
         #CH3OOH --> CH2O + HO2 + OH
-        Reaction(rate1(jCH3OOH), [CH3OOH], [CH2O, HO2, OH], [1], [1, 1, 1])
+        Reaction(jCH3OOH, [CH3OOH], [CH2O, HO2, OH], [1], [1, 1, 1])
         #HO2 + HO2 = H2O2 + O2
         Reaction(rate2(k17, T17), [HO2], [H2O2, O2], [2], [1, 1])
         #OH + H2O2 = H2O + HO2

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -57,32 +57,32 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         T = 280.0, [unit = u"K", description = "Temperature"],
         P = 101325, [unit = u"Pa", description = "Pressure (not directly used)"],
         num_density = 2.7e19, [description = "Number density of air (The units should be molecules/cm^3 but the equations here treat it as unitless)."],
-        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = us"ppb"],
-        CH4 = 1700.0, [isconstantspecies=true, unit = us"ppb"],
-        air_volume = 22400, [unit = u"cm^3/mol_air"],
-        ppb_unit = 1e-9, [unit = us"ppb", description = "Convert from mol/mol_air to ppb"],
+        O2 = 2.1 * (10.0^8), [isconstantspecies=true,unit = u"ppb"],
+        CH4 = 1700.0, [isconstantspecies=true, unit = u"ppb"],
+        ppb_unit = 1e-9, [unit = u"ppb", description = "Convert from mol/mol_air to ppb"],
     )
 
     species = @species(
-        O3(t) = 10.0, [unit = us"ppb"],
-        O1d(t) = 0.00001, [unit = us"ppb"],
-        OH(t) = 10.0, [unit = us"ppb"],
-        HO2(t) = 10.0, [unit = us"ppb"],
-        H2O(t) = 450.0, [unit = us"ppb"],
-        NO(t) = 0.0, [unit = us"ppb"],
-        NO2(t) = 10.0, [unit = us"ppb"],
-        CH3O2(t) = 0.01, [unit = us"ppb"],
-        CH2O(t) = 0.15, [unit = us"ppb"],
-        CO(t) = 275.0, [unit = us"ppb"],
-        CH3OOH(t) = 1.6, [unit = us"ppb"],
-        DMS(t) = 50, [unit = us"ppb"],
-        SO2(t) = 2.0, [unit = us"ppb"],
-        ISOP(t) = 0.15, [unit = us"ppb"],
-        H2O2(t) = 2.34, [unit = us"ppb"],
-        HNO3(t) = 10, [unit = us"ppb"],
+        O3(t) = 10.0, [unit = u"ppb"],
+        O1d(t) = 0.00001, [unit = u"ppb"],
+        OH(t) = 10.0, [unit = u"ppb"],
+        HO2(t) = 10.0, [unit = u"ppb"],
+        H2O(t) = 450.0, [unit = u"ppb"],
+        NO(t) = 0.0, [unit = u"ppb"],
+        NO2(t) = 10.0, [unit = u"ppb"],
+        CH3O2(t) = 0.01, [unit = u"ppb"],
+        CH2O(t) = 0.15, [unit = u"ppb"],
+        CO(t) = 275.0, [unit = u"ppb"],
+        CH3OOH(t) = 1.6, [unit = u"ppb"],
+        DMS(t) = 50, [unit = u"ppb"],
+        SO2(t) = 2.0, [unit = u"ppb"],
+        ISOP(t) = 0.15, [unit = u"ppb"],
+        H2O2(t) = 2.34, [unit = u"ppb"],
+        HNO3(t) = 10, [unit = u"ppb"],
     )
 
-    @constants P_hack = 1.0e20, [unit = us"Pa*ppb*s", description = "Constant for hack to avoid dropping pressure from the model"]
+    @constants R = 8.314e6 [unit = u"(Pa*cm^3)/(K*mol)", description = "universal gas constant"]
+    air_volume = R*T/P
     rate2(k, Tc) = k * exp(Tc / T) * A / air_volume * ppb_unit #Convert the second reaction rate value, which corresponds to species with units of molec/cm³, to ppb.
 
     function arr3(T, num_density, a1, b1, c1, a2, b2, c2, fv)
@@ -151,7 +151,7 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
         #OH + H2O2 = H2O + HO2
         Reaction(k18* A / air_volume * ppb_unit, [OH, H2O2], [H2O, HO2], [1, 1], [1, 1])
         #OH + CO = HO2
-        Reaction(k19* A / air_volume * ppb_unit + P/P_hack, [OH, CO], [HO2], [1, 1], [1])
+        Reaction(k19* A / air_volume * ppb_unit, [OH, CO], [HO2], [1, 1], [1])
         # FIXME(CT): Currently adding P*1e-20 to avoid pressure getting dropped from the model, so we can use it during coupling (for example, during emissions unit conversion).
     ]
     # We set `combinatoric_ratelaws=false` because we are modeling macroscopic rather than microscopic behavior. 
@@ -163,4 +163,3 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
     end
     convert(ODESystem, complete(rxns); metadata=Dict(:coupletype => SuperFastCoupler))
 end
-

--- a/src/fastjx_couplings.jl
+++ b/src/fastjx_couplings.jl
@@ -7,7 +7,7 @@ function EarthSciMLBase.couple2(c::GEOSChemGasPhaseCoupler, p::FastJXCoupler)
     ConnectorSystem([
             c.j_9 ~ uconv * p.j_h2o2
             c.j_7 ~ uconv * p.j_CH2Oa
-            c.j_8 ~ uconv * p.j_CH2Oa
+            c.j_8 ~ uconv * p.j_CH2Ob
             c.j_10 ~ uconv * p.j_CH3OOH
             c.j_11 ~ uconv * p.j_NO2
             c.j_3 ~ c_fixme1 * p.j_o31D

--- a/src/fastjx_couplings.jl
+++ b/src/fastjx_couplings.jl
@@ -1,12 +1,13 @@
 
 function EarthSciMLBase.couple2(c::GEOSChemGasPhaseCoupler, p::FastJXCoupler)
     c, p = c.sys, p.sys
-    c = param_to_var(c, :j_3, :j_9, :j_11, :j_7, :j_10)
+    c = param_to_var(c, :j_3, :j_9, :j_11, :j_7, :j_8, :j_10)
     @constants uconv = 1 [unit = u"s"]
     @constants c_fixme1 = 10^(-21) [unit = u"s", description="Suspicious constant"] # FIXME: Suspicious constant
     ConnectorSystem([
             c.j_9 ~ uconv * p.j_h2o2
             c.j_7 ~ uconv * p.j_CH2Oa
+            c.j_8 ~ uconv * p.j_CH2Oa
             c.j_10 ~ uconv * p.j_CH3OOH
             c.j_11 ~ uconv * p.j_NO2
             c.j_3 ~ c_fixme1 * p.j_o31D
@@ -15,10 +16,11 @@ end
 
 function EarthSciMLBase.couple2(c::SuperFastCoupler, p::FastJXCoupler)
     c, p = c.sys, p.sys
-    c = param_to_var(convert(ODESystem, c), :jO31D, :jH2O2, :jNO2, :jCH2Oa, :jCH3OOH)
+    c = param_to_var(convert(ODESystem, c), :jO31D, :jH2O2, :jNO2, :jCH2Oa, :jCH2Ob, :jCH3OOH)
     ConnectorSystem([
             c.jH2O2 ~ p.j_h2o2
             c.jCH2Oa ~ p.j_CH2Oa
+            c.jCH2Ob ~ p.j_CH2Ob
             c.jCH3OOH ~ p.j_CH3OOH
             c.jNO2 ~ p.j_NO2
             c.jO31D ~ p.j_o31D

--- a/test/EarthSciData_test.jl
+++ b/test/EarthSciData_test.jl
@@ -1,4 +1,4 @@
-using Main.GasChem, EarthSciData
+using GasChem, EarthSciData
 using Test, Dates, ModelingToolkit, DifferentialEquations, EarthSciMLBase, DynamicQuantities
 
 @testset "NEI2016Extension3way" begin
@@ -11,7 +11,7 @@ using Test, Dates, ModelingToolkit, DifferentialEquations, EarthSciMLBase, Dynam
     model_3way = couple(FastJX(), SuperFast(), emis)
 
     sys = structural_simplify(convert(ODESystem, model_3way))
-    @test length(unknowns(sys)) ≈ 18
+    @test length(unknowns(sys)) ≈ 16
 
     eqs = string(equations(sys))
     wanteq = "Differential(t)(SuperFast₊CH2O(t)) ~ SuperFast₊NEI2016MonthlyEmis_FORM(t)"
@@ -29,7 +29,7 @@ end
     model_3way = couple(FastJX(), SuperFast(), geosfp)
 
     sys = structural_simplify(convert(ODESystem, model_3way))
-    @test length(unknowns(sys)) ≈ 18
+    @test length(unknowns(sys)) ≈ 16
 
     eqs = string(equations(convert(ODESystem, model_3way)))
     wanteq = "SuperFast₊T(t) ~ GEOSFP₊I3₊T(t)"

--- a/test/EarthSciData_test.jl
+++ b/test/EarthSciData_test.jl
@@ -14,7 +14,8 @@ using Test, Dates, ModelingToolkit, DifferentialEquations, EarthSciMLBase, Dynam
     @test length(unknowns(sys)) ≈ 16
 
     eqs = string(equations(sys))
-    wanteq = "Differential(t)(SuperFast₊CH2O(t)) ~ SuperFast₊NEI2016MonthlyEmis_FORM(t)"
+    wanteq = "Differential(t)(SuperFast₊CO(t)) ~ SuperFast₊NEI2016MonthlyEmis_CO(t)"
+    #wanteq = "Differential(t)(SuperFast₊SO2(t)) ~ SuperFast₊NEI2016MonthlyEmis_SO2(t) + SuperFast₊NEI2016MonthlyEmis_SULF(t)"
     @test contains(string(eqs), wanteq)
 end
 

--- a/test/compose_fastjx_superfast_test.jl
+++ b/test/compose_fastjx_superfast_test.jl
@@ -5,7 +5,7 @@ using ModelingToolkit:t
 
 #   Unit Test
 @testset "2wayCoupling" begin
-    sol_middle = 9.943583315402849
+    sol_middle = 9.9476146376358
 
     sf = couple(SuperFast(), FastJX())
     combined_mtk = convert(ODESystem, sf)

--- a/test/compose_fastjx_superfast_test.jl
+++ b/test/compose_fastjx_superfast_test.jl
@@ -5,7 +5,7 @@ using ModelingToolkit:t
 
 #   Unit Test
 @testset "2wayCoupling" begin
-    sol_middle = 9.948004877573444
+    sol_middle = 9.999999736737555
 
     sf = couple(SuperFast(), FastJX())
     combined_mtk = convert(ODESystem, sf)

--- a/test/compose_fastjx_superfast_test.jl
+++ b/test/compose_fastjx_superfast_test.jl
@@ -5,18 +5,13 @@ using ModelingToolkit:t
 
 #   Unit Test
 @testset "2wayCoupling" begin
-    sol_middle = 9.999999736737555
+    sol_middle = 9.943583315402849
 
     sf = couple(SuperFast(), FastJX())
     combined_mtk = convert(ODESystem, sf)
     sys = structural_simplify(combined_mtk)
     tspan = (0.0, 3600 * 24)
-    sol = solve(
-        ODEProblem(sys, [], tspan, []),
-        Tsit5(),
-        saveat = 10.0,
-        abstol = 1e-8,
-        reltol = 1e-8,
-    )
+
+    sol = solve(ODEProblem(sys, [], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     @test sol[sys.SuperFast.O3][4320] ≈ sol_middle
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,18 @@ using GasChem
 using Test, SafeTestsets
 
 @testset "GasChem.jl" begin
-    # @safetestset "SuperFast" begin
-    #      include("superfast_test.jl")
-    # end
-    # @safetestset "FastJX" begin
-    #     include("fastjx_test.jl")
-    # end
-    # @safetestset "compose_fastjx_superfast" begin
-    #     include("compose_fastjx_superfast_test.jl")
-    # end
-    # @safetestset "geoschem_test" begin
-    #      include("geoschem_test.jl")
-    # end
+    @safetestset "SuperFast" begin
+         include("superfast_test.jl")
+    end
+    @safetestset "FastJX" begin
+        include("fastjx_test.jl")
+    end
+    @safetestset "compose_fastjx_superfast" begin
+        include("compose_fastjx_superfast_test.jl")
+    end
+    @safetestset "geoschem_test" begin
+         include("geoschem_test.jl")
+    end
     @safetestset "EarthSciData coupling" begin
          include("EarthSciData_test.jl")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,18 @@ using GasChem
 using Test, SafeTestsets
 
 @testset "GasChem.jl" begin
-    @safetestset "SuperFast" begin
-         include("superfast_test.jl")
-    end
-    @safetestset "FastJX" begin
-        include("fastjx_test.jl")
-    end
-    @safetestset "compose_fastjx_superfast" begin
-        include("compose_fastjx_superfast_test.jl")
-    end
-    @safetestset "geoschem_test" begin
-         include("geoschem_test.jl")
-    end
+    # @safetestset "SuperFast" begin
+    #      include("superfast_test.jl")
+    # end
+    # @safetestset "FastJX" begin
+    #     include("fastjx_test.jl")
+    # end
+    # @safetestset "compose_fastjx_superfast" begin
+    #     include("compose_fastjx_superfast_test.jl")
+    # end
+    # @safetestset "geoschem_test" begin
+    #      include("geoschem_test.jl")
+    # end
     @safetestset "EarthSciData coupling" begin
          include("EarthSciData_test.jl")
     end

--- a/test/superfast_test.jl
+++ b/test/superfast_test.jl
@@ -4,7 +4,7 @@ using DifferentialEquations, ModelingToolkit, DynamicQuantities
 tspan = (0.0, 360.0)
 
 @testset "Base case" begin
-    answer = 18.861830827565885
+    answer = 19.953178608397593
 
     rs = structural_simplify(SuperFast())
     sol = solve(
@@ -19,7 +19,7 @@ tspan = (0.0, 360.0)
 end
 
 @testset "DMS sensitivity" begin
-    u_dms = 0.8842096169345286
+    u_dms = 5.047129865154432e-7
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -43,7 +43,7 @@ end
 end
 
 @testset "ISOP sensitivity" begin
-    u_isop = 0.19386790460198
+    u_isop = -3.552713678800501e-14
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -67,7 +67,7 @@ end
 end
 
 @testset "NO2 sensitivity" begin
-    u_no2 = 45.85359224356945
+    u_no2 = 89.57860748723749
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -97,7 +97,7 @@ end
 end
 
 @testset "CO sensitivity" begin
-    u_co = -0.1938631791778107
+    u_co = 3.552713678800501e-15
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -121,7 +121,7 @@ end
 end
 
 @testset "CH4 sensitivity" begin
-    u_ch4 = 0.006664852234028018
+    u_ch4 = 1.0658141036401503e-14
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(

--- a/test/superfast_test.jl
+++ b/test/superfast_test.jl
@@ -4,7 +4,7 @@ using DifferentialEquations, ModelingToolkit, DynamicQuantities
 tspan = (0.0, 360.0)
 
 @testset "Base case" begin
-    answer = 18.408115665093476
+    answer = 17.204446308176035
     rs = structural_simplify(SuperFast())
     sol = solve(ODEProblem(rs, [], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
 
@@ -12,7 +12,7 @@ tspan = (0.0, 360.0)
 end
 
 @testset "DMS sensitivity" begin
-    u_dms = 8.542138107969777e-9
+    u_dms = 0.8231258833472341
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(ODEProblem(rs1, [rs1.DMS => 76], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
@@ -24,7 +24,7 @@ end
 end
 
 @testset "ISOP sensitivity" begin
-    u_isop = -0.0005144837357491383
+    u_isop = 0.15008086216045768
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(ODEProblem(rs1, [rs1.ISOP => 0.54], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
@@ -36,7 +36,7 @@ end
 end
 
 @testset "NO2 sensitivity" begin
-    u_no2 = 37.383664709630956
+    u_no2 = 35.75701073785234
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(ODEProblem(rs1, [rs1.NO2 => 100.0, rs1.DMS => 0.1], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
@@ -48,7 +48,7 @@ end
 end
 
 @testset "CO sensitivity" begin
-    u_co = -2.7440734129413613e-9
+    u_co = -0.1680113594146384
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(ODEProblem(rs1, [rs1.CO => 50.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
@@ -60,7 +60,7 @@ end
 end
 
 @testset "CH4 sensitivity" begin
-    u_ch4 = 4.362732397567015e-12
+    u_ch4 = 0.00463593346606217
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(ODEProblem(rs1, [rs1.CH4 => 1900.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)

--- a/test/superfast_test.jl
+++ b/test/superfast_test.jl
@@ -4,141 +4,68 @@ using DifferentialEquations, ModelingToolkit, DynamicQuantities
 tspan = (0.0, 360.0)
 
 @testset "Base case" begin
-    answer = 19.953178608397593
-
+    answer = 18.408115665093476
     rs = structural_simplify(SuperFast())
-    sol = solve(
-        ODEProblem(rs, [], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    sol = solve(ODEProblem(rs, [], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
 
     @test sol[rs.O3][end] ≈ answer
 end
 
 @testset "DMS sensitivity" begin
-    u_dms = 5.047129865154432e-7
+    u_dms = 8.542138107969777e-9
 
     rs1 = structural_simplify(SuperFast())
-    o1 = solve(
-        ODEProblem(rs1, [rs1.DMS => 76], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o1 = solve(ODEProblem(rs1, [rs1.DMS => 76], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     rs2 = structural_simplify(SuperFast())
-    o2 = solve(
-        ODEProblem(rs2, [rs2.DMS => 46], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o2 = solve(ODEProblem(rs2, [rs2.DMS => 46], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     test1 = o1[rs1.SO2][end] - o2[rs2.SO2][end]
 
     @test test1 ≈ u_dms
 end
 
 @testset "ISOP sensitivity" begin
-    u_isop = -3.552713678800501e-14
+    u_isop = -0.0005144837357491383
 
     rs1 = structural_simplify(SuperFast())
-    o1 = solve(
-        ODEProblem(rs1, [rs1.ISOP => 0.54], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o1 = solve(ODEProblem(rs1, [rs1.ISOP => 0.54], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     rs2 = structural_simplify(SuperFast())
-    o2 = solve(
-        ODEProblem(rs2, [rs2.ISOP => 0.13], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o2 = solve(ODEProblem(rs2, [rs2.ISOP => 0.13], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     test2 = o1[rs1.O3][end] - o2[rs2.O3][end]
 
     @test test2 ≈ u_isop
 end
 
 @testset "NO2 sensitivity" begin
-    u_no2 = 89.57860748723749
+    u_no2 = 37.383664709630956
 
     rs1 = structural_simplify(SuperFast())
-    o1 = solve(
-        ODEProblem(
-            rs1,
-            [rs1.NO2 => 100.0, rs1.DMS => 0.1],
-            tspan,
-            [],
-            combinatoric_ratelaws=false,
-        ),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o1 = solve(ODEProblem(rs1, [rs1.NO2 => 100.0, rs1.DMS => 0.1], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     rs2 = structural_simplify(SuperFast())
-    o2 = solve(
-        ODEProblem(rs2, [rs2.DMS => 0.1], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o2 = solve(ODEProblem(rs2, [rs2.DMS => 0.1], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     test3 = o1[rs1.O3][end] - o2[rs2.O3][end]
 
     @test test3 ≈ u_no2
 end
 
 @testset "CO sensitivity" begin
-    u_co = 3.552713678800501e-15
+    u_co = -2.7440734129413613e-9
 
     rs1 = structural_simplify(SuperFast())
-    o1 = solve(
-        ODEProblem(rs1, [rs1.CO => 50.0], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o1 = solve(ODEProblem(rs1, [rs1.CO => 50.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     rs2 = structural_simplify(SuperFast())
-    o2 = solve(
-        ODEProblem(rs2, [rs2.CO => 500.0], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o2 = solve(ODEProblem(rs2, [rs2.CO => 500.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     test4 = o1[rs1.O3][end] - o2[rs2.O3][end]
 
     @test test4 ≈ u_co
 end
 
 @testset "CH4 sensitivity" begin
-    u_ch4 = 1.0658141036401503e-14
+    u_ch4 = 4.362732397567015e-12
 
     rs1 = structural_simplify(SuperFast())
-    o1 = solve(
-        ODEProblem(rs1, [rs1.CH4 => 1900.0], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o1 = solve(ODEProblem(rs1, [rs1.CH4 => 1900.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     rs2 = structural_simplify(SuperFast())
-    o2 = solve(
-        ODEProblem(rs2, [rs2.CH4 => 1600.0], tspan, []),
-        Tsit5(),
-        saveat=10.0,
-        abstol=1e-12,
-        reltol=1e-12,
-    )
+    o2 = solve(ODEProblem(rs2, [rs2.CH4 => 1600.0], tspan, []),AutoTsit5(Rosenbrock23()), saveat=10.0)
     test5 = o1[rs1.O3][end] - o2[rs1.O3][end]
 
     @test test5 ≈ u_ch4


### PR DESCRIPTION
a. Include `HNO3` in SuperFast and dry deposition, add third-body reaction ✅
b. Remove reaction `13b` and species `CH3O` ✅
c. Change the rate of O(1D) + H2O from `2.2*10^-10 to 1.45*10^-10*exp(89/T)` ✅
d. Finish #TODOs, such as removing the unknown constant `c` = 2.46e10 in SuperFast reaction rate, and adding two branches of `CH2O` photolysis. ✅ 

After updating the documentation and tests, I ran some simulations for the box model; everything worked fine with changes a-c. However, the system became extremely unstable after the change d. 
The reason is the unit inconsistency between the reaction rate and the species for the second reaction. Therefore, I looked deeper into the `GEOS-CHEM KPP` module, SuperFast Paper, and other papers providing the same reaction rate value. I finally confirmed that the second reaction rate should be in units of "`cm³/molec/s`," and I transformed those values with species in units of "ppb" using `Avogadro's number` constant and a new parameter, `air_volume`. This happens to be close to the unknown constant `c` deleted. (I should have added notes to the calculated numbers in the code.)

This pull request is **not ready to be pulled** because: 
a. I need to update tests and documentation with the changes and unit conversions, and hopefully run the box model/3D model with better results. 
b. The Fullchem mechanism experienced the same unit inconsistency problem for the second and subsequent reactions, which needs to be fixed. 
c. I still haven't found a better way to include pressure `P` in SuperFast. If I don't include it in SuperFast, I won't be able to do the unit conversion when coupling NEI2016 and SuperFast.