### PR TITLE
HOTFIX: Add calibration factors to FastJX to make photolysis rates more reasonable

### DIFF
--- a/docs/src/superfast.md
+++ b/docs/src/superfast.md
@@ -29,7 +29,7 @@ Graph(SuperFast(;name=:SuperFast, rxn_sys=true))
 The chemical species included in the superfast model are:
 
 ```@example 1
-vars = unknowns(model)[1:13]
+vars = unknowns(model)[1:12]
 using DataFrames
 DataFrame(
         :Name => [string(Symbolics.tosymbol(v, escape=false)) for v ∈ vars],

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -260,13 +260,13 @@ function FastJX(; name=:FastJX)
     eqs = [
         cosSZA ~ cos_solar_zenith_angle(t, lat, long);
         fluxeqs;
-        j_h2o2 ~ j_mean_H2O2(T/T_unit, flux_vars);
-        j_CH2Oa ~ j_mean_CH2Oa(T/T_unit, flux_vars);
-        j_CH2Ob ~ j_mean_CH2Ob(T/T_unit, flux_vars);
-        j_o31D ~ j_mean_o31D(T/T_unit, flux_vars)*1e-17; #1e-17 is a parameter to adjust the calculated O(^3P)1D photolysis to appropriate magnitudes.
-        j_o32OH ~ j_o31D*adjust_j_o31D(T, P, H2O);
-        j_CH3OOH ~ j_mean_CH3OOH(T/T_unit, flux_vars);
-        j_NO2 ~ j_mean_NO2(T/T_unit, flux_vars)
+        j_h2o2 ~ j_mean_H2O2(T/T_unit, flux_vars)*0.0557; #0.0557 is a parameter to adjust the calculated H2O2 photolysis to appropriate magnitudes.
+        j_CH2Oa ~ j_mean_CH2Oa(T/T_unit, flux_vars)*0.945; #0.945 is a parameter to adjust the calculated CH2Oa photolysis to appropriate magnitudes.
+        j_CH2Ob ~ j_mean_CH2Ob(T/T_unit, flux_vars)*1.11; #1.11 is a parameter to adjust the calculated CH2Ob photolysis to appropriate magnitudes. 
+        j_o31D ~ j_mean_o31D(T/T_unit, flux_vars)*2.33e-21; #2.33e-21 is a parameter to adjust the calculated O(^3)1D photolysis to appropriate magnitudes.
+        j_o32OH ~ j_o31D*adjust_j_o31D(T, P, H2O); 
+        j_CH3OOH ~ j_mean_CH3OOH(T/T_unit, flux_vars)*0.0931; #0.0931 is a parameter to adjust the calculated CH3OOH photolysis to appropriate magnitudes.
+        j_NO2 ~ j_mean_NO2(T/T_unit, flux_vars)*1.03 #1.03 is a parameter to adjust the calculated NO2 photolysis to appropriate magnitudes.
     ]
 
     ODESystem(eqs, t, [j_h2o2, j_CH2Oa, j_CH2Ob, j_o32OH, j_o31D, j_CH3OOH, j_NO2, cosSZA, flux_vars...],

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -204,13 +204,13 @@ function SuperFast(;name=:SuperFast, rxn_sys=false)
             P = 101325, [unit = u"Pa", description = "Pressure"],
             O2 = 2.1e8, [isconstantspecies=true,unit = u"ppb"],
             CH4 = 1700.0, [isconstantspecies=true, unit = u"ppb"],
+            H2O = 450.0, [isconstantspecies=true, unit = u"ppb"],
         )
 
         @species(
             O3(t) = 20.0, [unit = u"ppb"],
             OH(t) = 0.01, [unit = u"ppb"],
             HO2(t) = 0.01, [unit = u"ppb"],
-            H2O(t) = 450.0, [unit = u"ppb"],
             NO(t) = 10.0, [unit = u"ppb"],
             NO2(t) = 10.0, [unit = u"ppb"],
             CH3O2(t) = 0.01, [unit = u"ppb"],

--- a/src/fastjx_couplings.jl
+++ b/src/fastjx_couplings.jl
@@ -13,7 +13,6 @@ end
 function EarthSciMLBase.couple2(c::SuperFastCoupler, p::FastJXCoupler)
     c, p = c.sys, p.sys
     c = param_to_var(convert(ODESystem, c), :jH2O2, :jNO2, :jCH2Oa, :jCH2Ob, :jCH3OOH, :jO32OH)
-    p = param_to_var(convert(ODESystem, p), :H2O)
     ConnectorSystem([
             c.jH2O2 ~ p.j_h2o2
             c.jCH2Oa ~ p.j_CH2Oa
@@ -21,6 +20,5 @@ function EarthSciMLBase.couple2(c::SuperFastCoupler, p::FastJXCoupler)
             c.jCH3OOH ~ p.j_CH3OOH
             c.jNO2 ~ p.j_NO2
             c.jO32OH ~ p.j_o32OH
-            c.H2O ~ p.H2O
         ], c, p)
 end

--- a/test/EarthSciData_test.jl
+++ b/test/EarthSciData_test.jl
@@ -15,7 +15,7 @@ using Test, Dates, ModelingToolkit, EarthSciMLBase
     model_3way = couple(FastJX(), SuperFast(), emis)
 
     sys = convert(ODESystem, model_3way)
-    @test length(unknowns(sys)) ≈ 13
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(equations(sys))
 
@@ -39,7 +39,7 @@ end
 
     sys = convert(ODESystem, model_3way)
 
-    @test length(unknowns(sys)) ≈ 13
+    @test length(unknowns(sys)) ≈ 12
 
     eqs = string(observed(sys))
     wanteq = "SuperFast₊T(t) ~ GEOSFP₊I3₊T(t)"

--- a/test/compose_fastjx_superfast_test.jl
+++ b/test/compose_fastjx_superfast_test.jl
@@ -4,7 +4,7 @@ using DifferentialEquations, ModelingToolkit, DynamicQuantities
 using ModelingToolkit:t
 
 @testset "2wayCoupling" begin
-    sol_middle = 10.054760542115613
+    sol_middle = 10.054760758144594
 
     sf = couple(SuperFast(), FastJX())
     sys = convert(ODESystem, sf)

--- a/test/superfast_test.jl
+++ b/test/superfast_test.jl
@@ -19,7 +19,7 @@ tspan = (0.0, 360.0)
 end
 
 @testset "ISOP sensitivity" begin
-    u_isop = 1.326627917253738
+    u_isop = 1.3266279542331567
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -73,7 +73,7 @@ end
 end
 
 @testset "CO sensitivity" begin
-    u_co = -3.2610694807314218
+    u_co = -3.2610697264494846
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(
@@ -97,7 +97,7 @@ end
 end
 
 @testset "CH4 sensitivity" begin
-    u_ch4 = 0.08634137924665097
+    u_ch4 = 0.08634138773470212
 
     rs1 = structural_simplify(SuperFast())
     o1 = solve(


### PR DESCRIPTION
Updates:
1. Calculate the FastJX ratio between the maximum model output and the level 38 reference value, and add that ratio as an adjustment parameter.
2. Change H2O to @parameters in SuperFast & Calculate H2O concentration from GEOSFP.

These updates are no ready to be merged into the main repository yet, because the unit tests and documentation have not been updated.