### PR TITLE
unify the namings of species in SuperFast and GEOS-Chem

### DIFF
--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -257,9 +257,9 @@ function SuperFast(; name = :SuperFast, rxn_sys = false)
             [unit=u"s^-1"],
             jNO2=0.0149,
             [unit=u"s^-1"],
-            jCH2Oa=0.00014,
+            jH2COa=0.00014,
             [unit=u"s^-1"],
-            jCH2Ob=0.00014,
+            jH2COb=0.00014,
             [unit=u"s^-1"],
             jCH3OOH=8.9573e-6,
             [unit=u"s^-1"],
@@ -329,8 +329,8 @@ function SuperFast(; name = :SuperFast, rxn_sys = false)
         jO32OH, O3 --> 2OH #simplified reaction of: O3 --> O2 + O1d; O1d + H2O --> 2OH
         jH2O2, H2O2 --> 2OH
         jNO2, NO2 --> NO + O3
-        jCH2Oa, CH2O --> HO2 + HO2 + CO
-        jCH2Ob, CH2O --> CO
+        jH2COa, CH2O --> HO2 + HO2 + CO
+        jH2COb, CH2O --> CO
         jCH3OOH, CH3OOH --> CH2O + HO2 + OH
     end
     rxns = compose(rx_sys, rate_systems)

--- a/src/fastjx_couplings.jl
+++ b/src/fastjx_couplings.jl
@@ -85,15 +85,15 @@ function EarthSciMLBase.couple2(c::SuperFastCoupler, p::FastJXCoupler)
         convert(ODESystem, c),
         :jH2O2,
         :jNO2,
-        :jCH2Oa,
-        :jCH2Ob,
+        :jH2COa,
+        :jH2COb,
         :jCH3OOH,
         :jO32OH
     )
     ConnectorSystem(
-        [c.jH2O2 ~ p.j_h2o2
-         c.jCH2Oa ~ p.j_CH2Oa
-         c.jCH2Ob ~ p.j_CH2Ob
+        [c.jH2O2 ~ p.j_H2O2
+         c.jH2COa ~ p.j_H2COa
+         c.jH2COb ~ p.j_H2COb
          c.jCH3OOH ~ p.j_CH3OOH
          c.jNO2 ~ p.j_NO2
          c.jO32OH ~ p.j_o32OH],

--- a/src/interpolations_FastJX.jl
+++ b/src/interpolations_FastJX.jl
@@ -103,10 +103,10 @@ function FastJX_interpolation_troposphere(t_ref::AbstractFloat; name = :FastJX)
     @parameters H2O = 450 [unit = u"ppb"]
     @parameters t_ref = t_ref [unit = u"s", description = "Reference Unix time"]
 
-    @variables j_h2o2(t) [unit = u"s^-1"]
-    @variables j_CH2Oa(t) [unit = u"s^-1"]
-    @variables j_CH2Ob(t) [unit = u"s^-1"]
-    @variables j_o31D(t) [unit = u"s^-1"]
+    @variables j_H2O2(t) [unit = u"s^-1"]
+    @variables j_H2COa(t) [unit = u"s^-1"]
+    @variables j_H2COb(t) [unit = u"s^-1"]
+    @variables j_O31D(t) [unit = u"s^-1"]
     @variables j_o32OH(t) [unit = u"s^-1"]
     @variables j_CH3OOH(t) [unit = u"s^-1"]
     @variables j_NO2(t) [unit = u"s^-1"]
@@ -116,18 +116,18 @@ function FastJX_interpolation_troposphere(t_ref::AbstractFloat; name = :FastJX)
 
     eqs = [cosSZA ~ cos_solar_zenith_angle(t + t_ref, lat, long);
            fluxeqs;
-           j_h2o2 ~ j_mean_H2O2(T/T_unit, flux_vars)*0.0557; #0.0557 is a parameter to adjust the calculated H2O2 photolysis to appropriate magnitudes.
-           j_CH2Oa ~ j_mean_CH2Oa(T/T_unit, flux_vars)*0.945; #0.945 is a parameter to adjust the calculated CH2Oa photolysis to appropriate magnitudes.
-           j_CH2Ob ~ j_mean_CH2Ob(T/T_unit, flux_vars)*0.813; #0.813 is a parameter to adjust the calculated CH2Ob photolysis to appropriate magnitudes.
-           j_o31D ~ j_mean_o31D(T/T_unit, flux_vars)*2.33e-21; #2.33e-21 is a parameter to adjust the calculated O(^3)1D photolysis to appropriate magnitudes.
-           j_o32OH ~ j_o31D*adjust_j_o31D(T, P, H2O);
+           j_H2O2 ~ j_mean_H2O2(T/T_unit, flux_vars);
+           j_H2COa ~ j_mean_H2COa(T/T_unit, flux_vars);
+           j_H2COb ~ j_mean_H2COb(T/T_unit, flux_vars);
+           j_O31D ~ j_mean_O31D(T/T_unit, flux_vars);
+           j_o32OH ~ j_O31D*adjust_j_O31D(T, P, H2O);
            j_CH3OOH ~ j_mean_CH3OOH(T/T_unit, flux_vars)*0.0931; #0.0931 is a parameter to adjust the calculated CH3OOH photolysis to appropriate magnitudes.
            j_NO2 ~ j_mean_NO2(T/T_unit, flux_vars)*0.444]
 
     ODESystem(
         eqs,
         t,
-        [j_h2o2, j_CH2Oa, j_CH2Ob, j_o32OH, j_o31D, j_CH3OOH, j_NO2, cosSZA, flux_vars...],
+        [j_H2O2, j_H2COa, j_H2COb, j_o32OH, j_O31D, j_CH3OOH, j_NO2, cosSZA, flux_vars...],
         [lat, long, T, P, H2O, t_ref];
         name = name,
         metadata = Dict(:coupletype => FastJXCoupler)

--- a/test/EarthSciData_test.jl
+++ b/test/EarthSciData_test.jl
@@ -49,7 +49,7 @@ end
     @test contains(eqs, wanteq) || contains(eqs, "SuperFast₊T(t) ~ FastJX₊T(t)")
     wanteq = "FastJX₊T(t) ~ GEOSFP₊I3₊T(t)"
     @test contains(eqs, wanteq) || contains(eqs, "FastJX₊T(t) ~ SuperFast₊T(t)")
-    wanteq = "SuperFast₊jH2O2(t) ~ FastJX₊j_h2o2(t)"
+    wanteq = "SuperFast₊jH2O2(t) ~ FastJX₊j_H2O2(t)"
     @test contains(eqs, wanteq)
     wanteq = "FastJX₊lat(t) ~ rad2deg(GEOSFP₊lat)"
     @test contains(eqs, wanteq)

--- a/test/fastjx_test.jl
+++ b/test/fastjx_test.jl
@@ -14,7 +14,7 @@ test_time = 3600 * 12.0
 #p = [0.0, 30.0, 0.0, 298.0, 101325, 450] # TODO(CT): Account for fact that parameters may not be in this order.
 p = [0.0, 40.0, -97.0, 298.0, 101325.0, 450.0 ]
 #   Unit Test 0: O3 -> O2 + O(1D)
-@testset "o31D" begin
+@testset "O31D" begin
     u_0 = [
         3.096786148141437e15,
         3.1007775166308335e15,
@@ -23,10 +23,10 @@ p = [0.0, 40.0, -97.0, 298.0, 101325.0, 450.0 ]
     ]
     fluxes = get_fluxes(3600 * 12.0, 30.0, 0.0, 0.9)
     test_0 = [
-        GasChem.j_mean_o31D(100.0, fluxes),
-        GasChem.j_mean_o31D(220.0, fluxes),
-        GasChem.j_mean_o31D(300.0, fluxes),
-        GasChem.j_mean_o31D(400.0, fluxes)
+        GasChem.j_mean_O31D(100.0, fluxes),
+        GasChem.j_mean_O31D(220.0, fluxes),
+        GasChem.j_mean_O31D(300.0, fluxes),
+        GasChem.j_mean_O31D(400.0, fluxes)
     ]
     @test test_0 ≈ u_0 rtol = 1e-6
 end
@@ -44,65 +44,62 @@ end
 
     @test test_1 ≈ u_1
 
-    H2O2_factor = 0.0557
     j_H2O2_func = ModelingToolkit.build_explicit_observed_function(
         fj,                # The system
-        [fj.j_h2o2]       # The observed variable we want
+        [fj.j_H2O2]       # The observed variable we want
     )
     j_H2O2_value = (j_H2O2_func([], p, test_time))[1]
     @test j_H2O2_value ≈
-          GasChem.j_mean_H2O2(298.0, get_fluxes(3600 * 12.0, 40.0, -97.0, 101325))*H2O2_factor rtol = 0.004
+          GasChem.j_mean_H2O2(298.0, get_fluxes(3600 * 12.0, 40.0, -97.0, 101325)) rtol = 0.004
 end
 
 # Unit Test 2: CH2O -> H + HO2 + CO
-@testset "CH2Oa" begin
+@testset "H2COa" begin
     u_2 = [8.642676785125311e-5, 8.64227156795509e-5, 8.641551181874694e-5]
 
     fluxes = get_fluxes(3600 * 12.0, 30.0, 0.0, 0.9)
     test_2 = [
-        GasChem.j_mean_CH2Oa(200.0, fluxes),
-        GasChem.j_mean_CH2Oa(250.0, fluxes),
-        GasChem.j_mean_CH2Oa(300.0, fluxes)
+        GasChem.j_mean_H2COa(200.0, fluxes),
+        GasChem.j_mean_H2COa(250.0, fluxes),
+        GasChem.j_mean_H2COa(300.0, fluxes)
     ]
 
     @test test_2 ≈ u_2
 
-    CH2Oa_factor = 0.945
-    j_CH2Oa_func = ModelingToolkit.build_explicit_observed_function(
+    j_H2COa_func = ModelingToolkit.build_explicit_observed_function(
         fj,                # The system
-        [fj.j_CH2Oa]       # The observed variable we want
+        [fj.j_H2COa]       # The observed variable we want
     )
-    j_CH2Oa_value = (j_CH2Oa_func([], p, test_time))[1]
-    @test j_CH2Oa_value ≈
-          GasChem.j_mean_CH2Oa(
+    j_H2COa_value = (j_H2COa_func([], p, test_time))[1]
+    @test j_H2COa_value ≈
+          GasChem.j_mean_H2COa(
         298.0,
         get_fluxes(3600 * 12.0, 40.0, -97.0, 101325)
-    )*CH2Oa_factor rtol = 1e-6
+    ) rtol = 1e-6
 end
 
-@testset "CH2Ob" begin
+@testset "H2COb" begin
     u_2 = [7.16264584129105e-5, 7.166900731492678e-5, 7.174464980740016e-5]
 
     fluxes = get_fluxes(3600 * 12.0, 30.0, 0.0, 0.9)
     test_2 = [
-        GasChem.j_mean_CH2Ob(200.0, fluxes),
-        GasChem.j_mean_CH2Ob(250.0, fluxes),
-        GasChem.j_mean_CH2Ob(300.0, fluxes)
+        GasChem.j_mean_H2COb(200.0, fluxes),
+        GasChem.j_mean_H2COb(250.0, fluxes),
+        GasChem.j_mean_H2COb(300.0, fluxes)
     ]
 
     @test test_2 ≈ u_2
 
-    CH2Ob_factor = 0.813
-    j_CH2Ob_func = ModelingToolkit.build_explicit_observed_function(
+    j_H2COb_func = ModelingToolkit.build_explicit_observed_function(
         fj,                # The system
-        [fj.j_CH2Ob]       # The observed variable we want
+        [fj.j_H2COb]       # The observed variable we want
     )
-    j_CH2Ob_value = (j_CH2Ob_func([], p, test_time))[1]
-    @test j_CH2Ob_value ≈
-          GasChem.j_mean_CH2Ob(
+    j_H2COb_value = (j_H2COb_func([], p, test_time))[1]
+    @test j_H2COb_value ≈
+          GasChem.j_mean_H2COb(
         298.0,
         get_fluxes(3600 * 12.0, 40.0, -97.0, 101325)
-    )*CH2Ob_factor rtol = 1e-6
+    ) rtol = 1e-6
 end
 
 # Unit Test 3: CH3OOH -> OH + HO2 + CH2O


### PR DESCRIPTION
### Summary
This PR unifies the naming of several repeating species in SuperFast and GEOS-Chem.  

Closes #134

### Changes
- `h2o2` → `H2O2`
- `CH2Oa` → `H2COa`
- `CH2Ob` → `H2COb`
- `o31D` → `O31D`

All updated species now use GEOS-Chem data for consistency.