### PR TITLE
PR 151

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ EarthSciMLBase = "0.24"
 Interpolations = "0.16"
 ModelingToolkit = "10"
 OrdinaryDiffEqRosenbrock = "1.10.1"
+SciMLBase = "2.114.0"
 StaticArrays = "1.9"
 SymbolicIndexingInterface = "0.3.42"
 TestItemRunner = "1.1.0"
@@ -40,9 +41,10 @@ julia = "1.10"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 EarthSciData = "a293c155-435f-439d-9c11-a083b6b47337"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["AllocCheck", "Test", "OrdinaryDiffEqRosenbrock", "EarthSciData", "SymbolicIndexingInterface", "TestItemRunner"]
+test = ["AllocCheck", "Test", "OrdinaryDiffEqRosenbrock", "EarthSciData", "SciMLBase", "SymbolicIndexingInterface", "TestItemRunner"]

--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -76,14 +76,9 @@ function EarthSciMLBase.couple2(
         [unit=u"kg/mol", description="Sulfur dioxide molar mass"],
         MW_ISOP=68.12e-3,
         [unit=u"kg/mol", description="Isoprene molar mass"],
-        nmolpermol=1e9,
-        [unit=u"ppb", description="nmol/mol, Conversion factor from mol to nmol"],
-        R=8.31446261815324,
-        [unit=u"m^3*Pa/mol/K", description="Ideal gas constant"],
-        NA=6.02214076e23,
-        [unit=u"molec/mol", description="The Avogadro constant"],
-        num_den_unit_conv = 1e6,
-        [unit = u"cm^3/m^3"],)
+        ppb_unit=1e9,
+        [unit=u"ppb", description="ppb unit"],
+        )
 
     # Emissions are in units of "kg/m3/s" and need to be converted to "ppb/s" or "nmol/mol/s".
     # To do this we need to convert kg of emissions to nmol of emissions,
@@ -92,7 +87,7 @@ function EarthSciMLBase.couple2(
     # mol_air = m3_air / R / T * P = m3 / (m3*Pa/mol/K) / K * Pa = mol
     # So, the overall conversion is:
     # nmol_emissions / mol_air = (kg_emissions / MW_emission * nmolpermol) / (m3_air / R / T * P)
-    uconv = NA * nmolpermol / (c.num_density * num_den_unit_conv)
+    uconv = ppb_unit / c.num_density
     #TODO(CT): Add missing couplings.
     operator_compose(
         convert(ODESystem, c),
@@ -150,16 +145,11 @@ function EarthSciMLBase.couple2(
     #TODO(CT): Add missing couplings.
     c = param_to_var(c, :T, :num_density)
     @constants(
-        R=8.31446261815324,
-        [unit=u"m^3*Pa/mol/K", description="Ideal gas constant"],
-        NA=6.02214076e23,
-        [unit=u"molec/mol", description="The Avogadro constant"],
-        num_den_unit_conv = 1e6,
-        [unit = u"cm^3/m^3"],
+        R=8.31446261815324, [unit=u"m^3*Pa/mol/K", description="Ideal gas constant"],
     )
     ConnectorSystem([
         c.T ~ gfp.I3₊T, 
-        c.num_density * num_den_unit_conv ~ (gfp.P / R * NA / gfp.I3₊T)
+        c.num_density  ~ (gfp.P / R / gfp.I3₊T)
         ], c, gfp)
 end
 

--- a/src/GasChem.jl
+++ b/src/GasChem.jl
@@ -14,7 +14,7 @@ using DocStringExtensions
 @register_unit molec 1
 @register_unit mol_air 1u"mol"
 @register_unit ppb 1u"mol/mol_air"
-#TODO if @register_unit ppb 1e-9u"mol/mol_air" if @register_unit ppb 1e-9u"mol/mol_air", though it's physically correct, but this will result ModelingToolkit.ValidationError when coupling different models.
+#TODO if @register_unit ppb 1e-9u"mol/mol_air", though it's physically correct, but this will result ModelingToolkit.ValidationError when coupling different models.
 
 include("SuperFast.jl")
 include("geoschem_ratelaws.jl")

--- a/src/geoschem_fullchem.jl
+++ b/src/geoschem_fullchem.jl
@@ -1078,14 +1078,14 @@ function GEOSChemGasPhase(; name = :GEOSChemGasPhase, rxn_sys = false)
             [unit=u"K", description="Temperature"],
             P=101325,
             [unit=u"Pa", description="Pressure"],
-            num_density=2.7e19,
+            num_density=2.7e19 / N_A * cm3_m3,
             [
-            unit = u"molec/cm^3",
+            unit = u"mol/m^3",
             description="Number density of air.",
             ],
             num_density_inv=1,
             [
-            unit = u"cm^3/molec",
+            unit = u"m^3/mol",
             description="multiply by num_density to obtain the unitless value of num_density",
             ],
             k_mt1=0,

--- a/src/geoschem_fullchem.jl
+++ b/src/geoschem_fullchem.jl
@@ -1074,7 +1074,12 @@ function GEOSChemGasPhase(; name = :GEOSChemGasPhase, rxn_sys = false)
             RCOOH(t)=12.892,
             [unit=u"ppb", description="C2H5C(O)OH; > C2 organic acids "],)
 
-        @parameters(T=298.15,
+        @parameters(
+            N_A=6.02214076e23,
+            [description="Avogadro's number"],
+            cm3_m3=1e6,
+            [description="Convert m3 to cm3"],
+            T=298.15,
             [unit=u"K", description="Temperature"],
             P=101325,
             [unit=u"Pa", description="Pressure"],

--- a/src/geoschem_fullchem.jl
+++ b/src/geoschem_fullchem.jl
@@ -1088,7 +1088,7 @@ function GEOSChemGasPhase(; name = :GEOSChemGasPhase, rxn_sys = false)
             unit = u"mol/m^3",
             description="Number density of air.",
             ],
-            num_density_inv=1,
+            num_density_inv= N_A / cm3_m3,
             [
             unit = u"m^3/mol",
             description="multiply by num_density to obtain the unitless value of num_density",

--- a/src/geoschem_ratelaws.jl
+++ b/src/geoschem_ratelaws.jl
@@ -2,6 +2,9 @@
 # Adapted from https://github.com/geoschem/geos-chem/tree/4722f288e90291ba904222f4bbe4fc216d17c34a/KPP/fullchem
 # The GEOS-Chem license applies: https://github.com/geoschem/geos-chem/blob/main/LICENSE.txt
 
+const N_A = 6.02214076e23 # Avogadro's number
+const cm3_m3 = 1e6
+
 """
 Function to create a constant rate coefficient for second-order reactions
 """
@@ -9,7 +12,7 @@ function constant_k(t, T, num_density, c; unit = u"ppb^-1*s^-1", name = :constan
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        c = c, [unit = u"molec^-1*cm^3*s^-1"]
+        c = c * N_A / cm3_m3, [unit = u"mol^-1*m^3*s^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
     end
     @variables(k(t), [unit = unit],)
@@ -34,10 +37,10 @@ function regress_T(t, T, num_density, a_0, b_0, T_0; name = :acet_oh)
     num_density = ParentScope(num_density)
     consts = @constants begin
         T_0 = T_0, [unit = u"K"]
-        a_0 = a_0 #[unit = u"cm^3*molec^-1*s^-1"]
-        b_0 = b_0 #[unit = u"cm^3*molec^-1*s^-1"]
+        a_0 = a_0
+        b_0 = b_0
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3*mol^-1*s^-1"]
     end
     @variables k(t) [unit = u"ppb^-1*s^-1"]
 
@@ -63,7 +66,7 @@ function arrhenius_ppb(
         b0 = b0
         c0 = c0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3*mol^-1*s^-1"]
     end
     @variables k(t) [unit = unit]
     C = num_density * ppb_unit * unit_conv

--- a/src/geoschem_ratelaws.jl
+++ b/src/geoschem_ratelaws.jl
@@ -536,7 +536,7 @@ function eq_const(
     num_density = ParentScope(num_density)
     @named k0 = arrhenius_ppb(t, T, num_density, a0, 0, c0)  # backwards rxn rate
     @named k1 = arr_3rdbody(t, T, num_density, a1, b1, 0, a2, b2, 0, fv)  # forwards rxn rate
-    @constants unit_conv = 1.0, [unit = unit]
+    consts = @constants unit_conv = 1.0, [unit = unit]
     @variables k(t) [unit = unit]
     ODESystem(
         [k ~ k1.k / k0.k * unit_conv], t, [k], consts; systems = [k0, k1], name = name)
@@ -743,30 +743,6 @@ function rate_GLYXNO3(t, T, num_density, a0, c0; name = :rate_GLYXNO3)
 end
 
 """
-Modified Arrhenius law with output in units `cm³·molec⁻¹·s⁻¹`.
-"""
-function arrplus_mlc(
-        t, T, a0, b0, c0, d0, e0; unit = u"cm^3*molec^-1*s^-1", name = :arrplus_mlc)
-    T = ParentScope(T)
-    consts = @constants begin
-        K_300 = 300, [unit = u"K"]
-        a0 = a0, [unit = unit]
-        b0 = b0, [unit = u"K"]
-        e0 = e0, [unit = u"K^-1"]
-        zero = 0.0, [unit = unit]
-    end
-    @variables(k(t), [unit = unit], kx(t), [unit = unit],)
-    ODESystem(
-        [kx ~ a0 * (d0 + (T * e0)) * exp(-b0 / T) * (T / K_300)^c0
-         k ~ max(kx, zero)],
-        t,
-        [k, kx],
-        consts;
-        name = name
-    )
-end
-
-"""
 Modified Arrhenius law with output in units `s⁻¹`.
 """
 function arrplus_mlc_1(t, T, a0, b0, c0, d0, e0; unit = u"s^-1", name = :arrplus_mlc_1)
@@ -819,33 +795,6 @@ function arrplus_ppb(
     )
 end
 
-"""
-Computes a temperature-dependent reaction rate constant using a modified
-Arrhenius expression with additional tunneling effect terms.
-Used to compute the rate for these reactions with output in units `cm³·molec⁻¹·s⁻¹`:
-IHOO1 = 1.5OH + ...
-IHOO4 = 1.5OH + ...
-"""
-function tunplus_mlc(
-        t, T, a0, b0, c0, d0, e0; unit = u"cm^3*molec^-1*s^-1", name = :tunplus_mlc)
-    T = ParentScope(T)
-    consts = @constants begin
-        a0 = a0, [unit = unit]
-        b0 = b0, [unit = u"K"]
-        c0 = c0, [unit = u"K^3"]
-        e0 = e0, [unit = u"K^-1"]
-        zero = 0.0, [unit = unit]
-    end
-    @variables(k0(t), [unit = unit], k(t), [unit = unit],)
-    ODESystem(
-        [k0 ~ a0 * (d0 + (T * e0)) * exp(b0 / T) * exp(c0 / T^3)
-         k ~ max(k0, zero)],
-        t,
-        [k0, k],
-        consts;
-        name = name
-    )
-end
 
 """
 Computes a temperature-dependent reaction rate constant using a modified

--- a/src/geoschem_ratelaws.jl
+++ b/src/geoschem_ratelaws.jl
@@ -55,14 +55,13 @@ Arrhenius equation:
     k = a0 * exp( c0 / T ) * (T/300)^b0
 ```
 """
-function arrhenius_ppb(
-        t, T, num_density, a0, b0, c0; unit = u"ppb^-1*s^-1", name = :arrhenius_ppb)
+function arrhenius_ppb(t, T, num_density, a0, b0, c0; unit = u"ppb^-1*s^-1", name = :arrhenius_ppb)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     t = ParentScope(t)
     consts = @constants begin
         K_300 = 300, [unit = u"K"]
-        a0 = a0 # [unit=u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         b0 = b0
         c0 = c0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
@@ -92,15 +91,15 @@ function arrhenius_ppb_3(
     t = ParentScope(t)
     consts = @constants begin
         K_300 = 300, [unit = u"K"]
-        a0 = a0, [unit = u"cm^6*molec^-2*s^-1"]
+        a0 = a0
         b0 = b0
         c0 = c0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
+        unit_conv = (N_A / cm3_m3)^2, [unit = u"m^6*mol^-2*s^-1"]
     end
     @variables k(t) [unit = unit]
-    C = num_density * ppb_unit
-    ODESystem([k ~ a0 * exp(c0 / T) * (K_300 / T)^b0 * C * C], t, [k], consts; name = name)
+    C = num_density^2 * ppb_unit^2 * unit_conv
+    ODESystem([k ~ a0 * exp(c0 / T) * (K_300 / T)^b0 * C], t, [k], consts; name = name)
 end
 
 """
@@ -119,7 +118,7 @@ function arrhenius_mlc_SI(
     t = ParentScope(t)
     consts = @constants begin
         K_300 = 300, [unit = u"K"]
-        a0 = a0 #[unit=unit],
+        a0 = a0
         b0 = b0
         c0 = c0, [unit = u"K"]
         unit_conv = 1e-6, [unit = u"m^3*molec^-1*s^-1"]
@@ -149,7 +148,6 @@ function arrhenius_mlc_1(t, T, a0, b0, c0; unit = u"s^-1", name = :arrhenius_mlc
         c0 = c0, [unit = u"K"]
     end
     @variables k(t) [unit = unit]
-    # (XY 7/1/2025 First-order reaction, no need to convert unit)
     ODESystem([k ~ a0 * exp(c0 / T) * (K_300 / T)^b0], t, [k], consts; name = name)
 end
 
@@ -167,23 +165,22 @@ function arr_3rdbody(t, T, num_density, a1, b1, c1, a2, b2, c2, fv; unit = u"ppb
     num_density = ParentScope(num_density)
     consts = @constants begin
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @named alow = arrhenius_mlc_SI(t, T, a1, b1, c1)
     @named ahigh = arrhenius_mlc_SI(t, T, a2, b2, c2)
-    rlow = alow.k * num_density * num_density_unit_inv #mlc/cc
-    rhigh = ahigh.k
-    xyrat = rlow / rhigh #no unit
+    rlow = alow.k * k_unit_inv * num_density * num_density_unit_inv
+    rhigh = ahigh.k * k_unit_inv
+    xyrat = rlow / rhigh
     blog = log10(xyrat)
     fexp = 1.0 / (1.0 + (blog * blog))
 
     @variables k(t) [unit = unit]
-    C = num_density * ppb_unit
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [k ~ rlow * (fv^fexp) / (1.0 + xyrat) * unit_conv * C],
+        [k ~ rlow * (fv^fexp) / (1.0 + xyrat) * C],
         t, [k],
         consts;
         systems = [alow, ahigh],
@@ -205,18 +202,20 @@ function arr_3rdbody_1(t, T, num_density, a1, b1, c1, a2, b2, c2, fv;
     num_density = ParentScope(num_density)
     consts = @constants begin
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit = 1.0, [unit = u"molec/cm^3"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0, [unit = u"s^-1"]
     end
     @named alow = arrhenius_mlc_SI(t, T, a1, b1, c1)
     @named ahigh = arrhenius_mlc_SI(t, T, a2, b2, c2)
-    rlow = alow.k * num_density #s^-1
-    rhigh = ahigh.k * num_density_unit #s^-1
-    xyrat = rlow / rhigh #no unit
-    blog = log10(xyrat) #no unit
-    fexp = 1.0 / (1.0 + (blog * blog)) #no unit
+    rlow = alow.k * k_unit_inv * num_density * num_density_unit_inv
+    rhigh = ahigh.k * k_unit_inv
+    xyrat = rlow / rhigh
+    blog = log10(xyrat)
+    fexp = 1.0 / (1.0 + (blog * blog))
     @variables k(t) [unit = unit]
     ODESystem(
-        [k ~ rlow * (fv^fexp) / (1.0 + xyrat)],
+        [k ~ rlow * (fv^fexp) / (1.0 + xyrat) * unit_conv],
         t,
         [k],
         consts;
@@ -237,22 +236,18 @@ function rate_HO2HO2(t, T, num_density, H2O, a0, c0, a1, c1; name = :rate_HO2HO2
     @named k1 = arrhenius_mlc_SI(t, T, a1, 0.0, c1)
     consts = @constants begin
         T_0 = 2200.0, [unit = u"K"]
-        one = 1.0, [unit = u"molec/cm^3"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-
-    C = num_density * ppb_unit
-    #(XY 7/1/2025): Here H2O is in ppb, we need to convert it back to molec/cc to meet the unit of 1.4E-21
+    C_H2O = num_density * num_density_unit_inv * ppb_unit
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [   #ppb^-1 * (k0.k + k1.k * num_density) * (one + 1.4E-21 * H2O * exp(T_0 / T))
-            k ~ (k0.k * unit_conv + k1.k * unit_conv * num_density * num_density_unit_inv) *
-                ((one * unit_conv + 1.4E-21 * (H2O * unit_conv * C) * exp(T_0 / T)) /
-                 (unit_conv / C) / one)
+        [
+            k ~ (k0.k * k_unit_inv + k1.k * k_unit_inv * num_density * num_density_unit_inv) *
+                ((1.0 + 1.4E-21 * (H2O * C_H2O) * exp(T_0 / T))) * C
         ],
         t,
         [k],
@@ -271,27 +266,26 @@ function rate_OHCO(t, T, num_density; name = :rate_OHCO)
     num_density = ParentScope(num_density)
     consts = @constants begin
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1.0,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @named klo1 = arrhenius_mlc_SI(t, T, 5.9E-33, 1, 0)
     @named khi1 = arrhenius_mlc_SI(t, T, 1.1E-12, -1.3, 0)
-    xyrat1 = klo1.k * num_density * num_density_unit_inv / khi1.k #no unit
+    xyrat1 = klo1.k * num_density * num_density_unit_inv / khi1.k
     blog1 = log10(xyrat1)
     fexp1 = 1.0 / (1.0 + blog1 * blog1)
-    kco1 = klo1.k * unit_conv * num_density * num_density_unit_inv * 0.6^fexp1 /
-           (1.0 + xyrat1) # cm^3/molec/s
+    kco1 = klo1.k * k_unit_inv * num_density * num_density_unit_inv * 0.6^fexp1 /
+           (1.0 + xyrat1) 
     @named klo2 = arrhenius_mlc_SI(t, T, 1.5E-13, 0, 0)
     @named khi2 = arrhenius_mlc_SI(t, T, 2.1E+09, -6.1, 0)
-    xyrat2 = klo2.k * num_density * num_density_unit_inv / khi2.k # no unit
+    xyrat2 = klo2.k * num_density * num_density_unit_inv / khi2.k
     blog2 = log10(xyrat2)
     fexp2 = 1.0 / (1.0 + blog2 * blog2)
-    kco2 = klo2.k * unit_conv * 0.6^fexp2 / (1.0 + xyrat2) # cm^3/molec/s
+    kco2 = klo2.k * k_unit_inv * 0.6^fexp2 / (1.0 + xyrat2) 
 
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
         [k ~ kco1 * C + kco2 * C],
         t,
@@ -321,11 +315,12 @@ function rate_RO2NO_a1(t, T, num_density, a0, c0; name = :rate_RO2NO_a1)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         c0 = c0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     @variables k(t) [unit = u"ppb^-1*s^-1"]
     ODESystem([k ~ a0 * exp(c0 / T) * 3.0e-4 * C], t, [k], consts; name = name)
 end
@@ -344,13 +339,14 @@ function rate_RO2NO_b1(t, T, num_density, a0, c0; name = :rate_RO2NO_b1)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         c0 = c0, [unit = u"K"]
         fyrno3 = 3.0e-4
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a0 * exp(c0 / T) * (1 - fyrno3) * C], t, [k], consts; name = name)
 end
 
@@ -366,33 +362,28 @@ function rate_RO2NO_a2(t, T, num_density, a0, c0, a1; name = :rate_RO2NO_a2)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        one_s = 1.0, [unit = u"s"]
-        one_ppb = 1.0, [unit = u"ppb"]
-        inv_ppb = 1.0, [unit = u"ppb^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
-        oneunit_yyyn = 1.0, [unit = u"molec/cm^3*s"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
 
     @named k0 = arrhenius_mlc_SI(t, T, a0, 0, c0)
-    @named yyyn = arrhenius_mlc_SI(t, T, 0.826, 8.1, 0.0)  # no unit
-    @variables(xxyn(t), #[unit = u"cm^3*molec^-1*s^-1"]
+    @named yyyn = arrhenius_mlc_SI(t, T, 0.826, 8.1, 0.0)
+    @variables(xxyn(t), 
         aaa(t),
         zzyn(t),
         rarb(t),
         fyrno3(t),
         k(t), [unit = u"ppb^-1*s^-1"])
-    C = num_density * ppb_unit  # molec/cm³ → ppb
-    eqs = [xxyn ~ 1.94e-22 * exp(0.97 * a1) * num_density * num_density_unit_inv #no unit
-           aaa ~ log10(xxyn / (yyyn.k * unit_conv * oneunit_yyyn)) #no unit
-           zzyn ~ (1.0 / (1.0 + (aaa * aaa))) #no unit
-           rarb ~ (xxyn / (1.0 + (xxyn / (yyyn.k * unit_conv * oneunit_yyyn)))) *
-                  (0.411^zzyn) #no unit
-           fyrno3 ~ (rarb / (1.0 + rarb)) #no unit
-           k ~ k0.k * unit_conv * fyrno3 * C]
+    C = num_density * ppb_unit * unit_conv
+    eqs = [xxyn ~ 1.94e-22 * exp(0.97 * a1) * num_density * num_density_unit_inv
+           aaa ~ log10(xxyn / (yyyn.k * k_unit_inv))
+           zzyn ~ (1.0 / (1.0 + (aaa * aaa)))
+           rarb ~ (xxyn / (1.0 + (xxyn / (yyyn.k * k_unit_inv)))) *
+                  (0.411^zzyn)
+           fyrno3 ~ (rarb / (1.0 + rarb))
+           k ~ k0.k * k_unit_inv * fyrno3 * C]
     ODESystem(
         eqs,
         t,
@@ -417,34 +408,28 @@ function rate_RO2NO_b2(t, T, num_density, a0, c0, a1; name = :rate_RO2NO_b2)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        one_s = 1.0, [unit = u"s"]
-        one_ppb = 1.0, [unit = u"ppb"]
-        inv_ppb = 1.0, [unit = u"ppb^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
-        oneunit_yyyn = 1.0, [unit = u"molec/cm^3*s"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @named k0 = arrhenius_mlc_SI(t, T, a0, 0.0, c0)
     @named yyyn = arrhenius_mlc_SI(t, T, 0.826, 8.1, 0.0)
     vars = @variables begin
-        xxyn(t) # [unit = u"cm^3*molec^-1*s^-1"]
+        xxyn(t)
         aaa(t)
         zzyn(t)
         rarb(t)
         fyrno3(t)
         k(t), [unit = u"ppb^-1*s^-1"]
     end
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     eqs = [xxyn ~ 1.94e-22 * exp(0.97 * a1) * num_density * num_density_unit_inv
-           aaa ~ log10(xxyn / (yyyn.k * unit_conv * oneunit_yyyn))
+           aaa ~ log10(xxyn / (yyyn.k * k_unit_inv))
            zzyn ~ (1.0 / (1.0 + (aaa * aaa)))
-           rarb ~ (xxyn / (1.0 + (xxyn / (yyyn.k * unit_conv * oneunit_yyyn)))) *
-                  (0.411^zzyn)
+           rarb ~ (xxyn / (1.0 + (xxyn / (yyyn.k * k_unit_inv )))) * (0.411^zzyn)
            fyrno3 ~ (rarb / (1.0 + rarb))
-           k ~ k0.k * unit_conv * (1.0 - fyrno3) * C]
+           k ~ k0.k * k_unit_inv * (1.0 - fyrno3) * C]
     ODESystem(
         eqs,
         t,
@@ -463,15 +448,15 @@ function tbranch(t, T, num_density, a0, b0, c0, a1, b1, c1; name = :tbranch)
     num_density = ParentScope(num_density)
     consts = @constants begin
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
-        ones = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
     end
     @named k0 = arrhenius_mlc_SI(t, T, a0, b0, c0)
     @named k1 = arrhenius_mlc_SI(t, T, a1, b1, c1)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [k ~ (k0.k / (ones / unit_conv + k1.k)) * C * ones],
+        [k ~ (k0.k * k_unit_inv / (1.0 + k1.k * k_unit_inv)) * C],
         t,
         [k],
         consts;
@@ -493,17 +478,16 @@ function rate_OHHNO3(t, T, num_density, a0, c0, a1, c1, a2, c2; name = :rate_OHH
     @named k1 = arrhenius_mlc_SI(t, T, a1, 0, c1)
     @named k1_5 = arrhenius_mlc_SI(t, T, a2, 0, c2)
     consts = @constants begin
-        num_density_unit_inv = 1,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
-    k2 = num_density * k1_5.k * num_density_unit_inv # m^3/molec/s
+    k2 = (num_density * num_density_unit_inv) * (k1_5.k * k_unit_inv)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [k ~ k0.k * unit_conv * C + k2 * unit_conv * C / (1.0 + k2 / k1.k)],
+        [k ~ k0.k * k_unit_inv * C + k2 * C / (1.0 + k2 / (k1.k * k_unit_inv))],
         t,
         [k],
         consts;
@@ -521,20 +505,7 @@ Used to compute the rate for these reactions:
 PPN        = RCO3 + NO2
 PAN        = MCO3 + NO2
 """
-function eq_const(
-        t,
-        T,
-        num_density,
-        a0,
-        c0,
-        a1,
-        b1,
-        a2,
-        b2,
-        fv;
-        unit = u"ppb^-1*s^-1",
-        name = :eq_const
-)
+function eq_const(t, T, num_density, a0, c0, a1, b1, a2, b2, fv; unit = u"ppb^-1*s^-1", name = :eq_const)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     @named k0 = arrhenius_ppb(t, T, num_density, a0, 0, c0)  # backwards rxn rate
@@ -603,14 +574,15 @@ function rate_GLYCOH_a(t, T, num_density, a0; name = :rate_GLYCOH_a)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         exp_arg = -1.0 / 73.0, [unit = u"K^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     glyc_frac = 1.0 - 11.0729 * exp(exp_arg * T)
     glyc_frac = max(glyc_frac, 0.0)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a0 * glyc_frac * C], t, [k], consts; name = name)
 end
 
@@ -627,14 +599,15 @@ function rate_GLYCOH_b(t, T, num_density, a0; name = :rate_GLYCOH_b)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         exp_arg = -1.0 / 73.0, [unit = u"K^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     glyc_frac = 1.0 - 11.0729 * exp(exp_arg * T)
     glyc_frac = max(glyc_frac, 0.0)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a0 * (1.0 - glyc_frac) * C], t, [k], consts; name = name)
 end
 
@@ -648,16 +621,17 @@ function rate_HACOH_a(t, T, num_density, a0, c0; name = :rate_HACOH_a)
     num_density = ParentScope(num_density)
     consts = @constants begin
         exp_arg = -1.0 / 60.0, [unit = u"K^-1"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     k0 = arrhenius_mlc_SI(t, T, a0, 0, c0)
     hac_frac = 1.0 - 23.7 * exp(exp_arg * T)
     hac_frac = max(hac_frac, 0.0)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [k ~ k0.k * unit_conv * hac_frac * C], t, [k], consts; systems = [k0], name = name)
+        [k ~ k0.k * k_unit_inv * hac_frac * C], t, [k], consts; systems = [k0], name = name)
 end
 
 """
@@ -670,15 +644,16 @@ function rate_HACOH_b(t, T, num_density, a0, c0; name = :rate_HACOH_b)
     num_density = ParentScope(num_density)
     consts = @constants begin
         exp_arg = -1.0 / 60.0, [unit = u"K^-1"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     k0 = arrhenius_mlc_SI(t, T, a0, 0, c0)
     hac_frac = 1.0 - 23.7 * exp(exp_arg * T)
     hac_frac = max(hac_frac, 0.0)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
-    ODESystem([k ~ k0.k * unit_conv * (1.0 - hac_frac) * C],
+    C = num_density * ppb_unit * unit_conv
+    ODESystem([k ~ k0.k * k_unit_inv * (1.0 - hac_frac) * C],
         t, [k], consts; systems = [k0], name = name)
 end
 
@@ -690,23 +665,20 @@ function rate_DMSOH(t, T, num_density, a0, c0, a1, c1; name = :rate_DMSOH)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        num_density_unit_inv = 1.0,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        #unit_conv = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
-        c2 = 0.2095e0 #[unit = u"ppb"]
+        c2 = 0.2095e0
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
-        ones = 1.0, [unit = u"cm^3*molec^-1*s^-1"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @named k0 = arrhenius_mlc_SI(t, T, a0, 0, c0)
     @named k1 = arrhenius_mlc_SI(t, T, a1, 0, c1)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
         #[k ~ unit_conv * (k0.k * num_density * c2) / (1 / one_s + k1.k * c2)],
-        [k ~ (k0.k * num_density * num_density_unit_inv * c2) /
-             (ones / unit_conv + k1.k * c2) * ones * C],
+        [k ~ (k0.k * k_unit_inv * num_density * num_density_unit_inv * c2) /
+             (1.0 + k1.k * k_unit_inv * c2) * C],
         t,
         [k],
         consts;
@@ -724,19 +696,18 @@ function rate_GLYXNO3(t, T, num_density, a0, c0; name = :rate_GLYXNO3)
     # ---  K = K1*([O2]+3.5D18)/(2*[O2]+3.5D18)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
-    O2 = num_density * 0.2095 #molec/cc
     @named k0 = arrhenius_mlc_SI(t, T, a0, 0, c0)
     consts = @constants begin
-        ones = 1.0, [unit = u"molec/cm^3"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        k_unit_inv = 1e6, [unit = u"m^-3*molec*s", description = "multiply by k to obtain cm^3*molec^-1*s^-1-based unitless value of k"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1e6, [unit = u"cm^3/m^3"]
-        num_density_unit_inv = 1.0, [unit = u"cm^3/molec"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    O2 = num_density * num_density_unit_inv * 0.2095
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
-        [k ~ k0.k * unit_conv * (O2 * num_density_unit_inv + 3.5E+18) /
-             (2.0 * O2 * num_density_unit_inv + 3.5E+18) * C],
+        [k ~ k0.k * k_unit_inv * (O2 + 3.5E+18) / (2.0 * O2 + 3.5E+18) * C],
         t,
         [k],
         consts;
@@ -780,14 +751,15 @@ function arrplus_ppb(
     num_density = ParentScope(num_density)
     consts = @constants begin
         K_300 = 300, [unit = u"K"]
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         b0 = b0, [unit = u"K"]
         e0 = e0, [unit = u"K^-1"]
         zero = 0.0, [unit = unit]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @variables(k(t), [unit = unit], kx(t), [unit = unit],)
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
         [kx ~ a0 * (d0 + (T * e0)) * exp(-b0 / T) * (T / K_300)^c0 * C
          k ~ max(kx, zero)],
@@ -839,15 +811,16 @@ function tunplus_ppb(
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         b0 = b0, [unit = u"K"]
         c0 = c0, [unit = u"K^3"]
         e0 = e0, [unit = u"K^-1"]
         zero = 0.0, [unit = unit]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     @variables(k0(t), [unit = unit], k(t), [unit = unit],)
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem(
         [k0 ~ a0 * (d0 + (T * e0)) * exp(b0 / T) * exp(c0 / T^3) * C
          k ~ max(k0, zero)],
@@ -868,17 +841,18 @@ function rate_ISO1(t, T, num_density, a0, b0, c0, d0, e0, f0, g0; name = :rate_I
     num_density = ParentScope(num_density)
     consts = @constants begin
         ct = 1.0E8, [unit = u"K^3"]
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         b0 = b0, [unit = u"K"]
         e0 = e0, [unit = u"K"]
         g0 = g0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
-    k0 = d0 * exp(e0 / T) * exp(ct / T^3) #no unit
-    k1 = f0 * exp(g0 / T) #no unit
-    k2 = c0 * k0 / (k0 + k1) #no unit
+    k0 = d0 * exp(e0 / T) * exp(ct / T^3)
+    k1 = f0 * exp(g0 / T)
+    k2 = c0 * k0 / (k0 + k1)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a0 * exp(b0 / T) * (1.0 - k2) * C], t, [k], consts; name = name)
 end
 
@@ -897,17 +871,18 @@ function rate_ISO2(t, T, num_density, a0, b0, c0, d0, e0, f0, g0; name = :rate_I
     num_density = ParentScope(num_density)
     consts = @constants begin
         ct = 1.0E8, [unit = u"K^3"]
-        a0 = a0, [unit = u"cm^3*molec^-1*s^-1"]
+        a0 = a0
         b0 = b0, [unit = u"K"]
         e0 = e0, [unit = u"K"]
         g0 = g0, [unit = u"K"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     k0 = d0 * exp(e0 / T) * exp(ct / T^3)
     k1 = f0 * exp(g0 / T)
     k2 = c0 * k0 / (k0 + k1)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a0 * exp(b0 / T) * k2 * C], t, [k], consts; name = name)
 end
 
@@ -931,15 +906,14 @@ function rate_EPO(t, T, num_density, a1, e1, m1; name = :rate_EPO)
     num_density = ParentScope(num_density)
     consts = @constants begin
         e1 = e1, [unit = u"K"]
-        a1 = a1, [unit = u"cm^3*molec^-1*s^-1"]
+        a1 = a1
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1.0,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
-    k1 = 1.0 / (m1 * num_density * num_density_unit_inv + 1.0) #no unit
+    k1 = 1.0 / (m1 * num_density * num_density_unit_inv + 1.0)
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ a1 * exp(e1 / T) * k1 * C], t, [k], consts; name = name)
 end
 
@@ -947,34 +921,25 @@ end
 Used to compute the rate for reaction:
 BZPAN --> BZCO3 + NO2
 """
-function rate_PAN_abab(
-        t,
-        T,
-        num_density,
-        a0,
-        b0,
-        a1,
-        b1,
-        cf;
-        unit = u"s^-1",
-        name = :rate_PAN_abab
-)
+function rate_PAN_abab(t, T, num_density, a0, b0, a1, b1, cf; unit = u"s^-1", name = :rate_PAN_abab)
     T = ParentScope(T)
     num_density = ParentScope(num_density)
     consts = @constants begin
-        a0 = a0, [unit = u"cm^3/molec/s"]
-        a1 = a1, [unit = u"s^-1"]
+        a0 = a0
+        a1 = a1
         b0 = b0, [unit = u"K"]
         b1 = b1, [unit = u"K"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 , [unit = u"s^-1"]
     end
-    k0 = a0 * exp(b0 / T) #cm^3/molec/s
-    k1 = a1 * exp(b1 / T) #1/s
-    k0 = k0 * num_density #1/s
-    kr = k0 / k1 #no unit
-    nc = 0.75 - 1.27 * (log10(cf)) #no unit
-    f = 10.0^(log10(cf) / (1.0 + (log10(kr) / nc)^2)) #no unit
+    k0 = a0 * exp(b0 / T)
+    k1 = a1 * exp(b1 / T)
+    k0 = k0 * num_density * num_density_unit_inv
+    kr = k0 / k1
+    nc = 0.75 - 1.27 * (log10(cf))
+    f = 10.0^(log10(cf) / (1.0 + (log10(kr) / nc)^2))
     @variables k(t) [unit = unit]
-    ODESystem([k ~ k0 * k1 * f / (k0 + k1)], t, [k], consts; name = name)
+    ODESystem([k ~ k0 * k1 * f / (k0 + k1) * unit_conv], t, [k], consts; name = name)
 end
 
 """
@@ -988,18 +953,20 @@ function rate_PAN_acac(t, T, num_density, a0, c0, a1, c1, cf; name = :rate_PAN_a
     num_density = ParentScope(num_density)
     consts = @constants begin
         K_300 = 300, [unit = u"K"]
-        a0 = a0, [unit = u"cm^6/molec^2/s"]
-        a1 = a1, [unit = u"cm^3/molec/s"]
+        a0 = a0
+        a1 = a1
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     k0 = a0 * (T / K_300)^c0
     k1 = a1 * (T / K_300)^c1
-    k0 = k0 * num_density
+    k0 = k0 * num_density * num_density_unit_inv
     kr = k0 / k1 # no unit
     nc = 0.75 - 1.27 * (log10(cf))# no unit
     f = 10.0^(log10(cf) / (1.0 + (log10(kr) / nc)^2)) # no unit
     @variables k(t) [unit = u"ppb^-1*s^-1"]
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     ODESystem([k ~ k0 * k1 * f / (k0 + k1) * C], t, [k], consts; name = name)
 end
 
@@ -1034,10 +1001,8 @@ function rate_NIT(t, T, num_density, a0, b0, c0, n, x0, y0; name = :rate_NIT)
         y0 = y0, [unit = u"K^-1"]
         zero = 0.0, [unit = u"ppb^-1*s^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        num_density_unit_inv = 1.0,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
-        unit_conv = 1.0, [unit = u"cm^3/molec*s^-1"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     vars = @variables begin
         k0(t)
@@ -1045,17 +1010,17 @@ function rate_NIT(t, T, num_density, a0, b0, c0, n, x0, y0; name = :rate_NIT)
         k2_(t)
         k2(t)
         k3(t)
-        k4(t) #[unit = u"ppb^-1*s^-1"]
+        k4(t)
         kx(t), [unit = u"ppb^-1*s^-1"]
         k(t), [unit = u"ppb^-1*s^-1"]
     end
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     eqs = [k0 ~ 2.0E-22 * exp(n) * (num_density * num_density_unit_inv)
            k1 ~ k0 / (4.3E-1 * (T / T_298)^(-8))
            k2_ ~ (k0 / (1.0 + k1)) * 4.1E-1^(1.0 / (1.0 + (log10(k1))^2))
            k3 ~ k2_ / (k2_ + c0)
            k4 ~ a0 * (x0 - T * y0)
-           kx ~ k4 * exp(b0 / T) * k3 * (C * unit_conv)
+           kx ~ k4 * exp(b0 / T) * k3 * C
            k ~ max(kx, zero)]
     ODESystem(eqs, t, vars, consts; name = name)
 end
@@ -1093,27 +1058,25 @@ function rate_ALK(t, T, num_density, a0, b0, c0, n, x0, y0; name = :rate_ALK)
         y0 = y0, [unit = u"K^-1"]
         zero = 0, [unit = u"ppb^-1*s^-1"]
         ppb_unit = 1e-9, [unit = u"ppb^-1", description = "Convert from mol/mol_air to ppb"]
-        unit_conv = 1.0, [unit = u"cm^3/molec*s^-1"]
-        num_density_unit_inv = 1.0,
-        [unit = u"cm^3/molec",
-            description = "multiply by num_density to obtain the unitless value of num_density"]
+        num_density_unit_inv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol", description = "multiply by num_density to obtain SI-based unitless value of num_density"]
+        unit_conv = 1.0 / cm3_m3 * N_A, [unit = u"m^3/mol/s"]
     end
     vars = @variables begin
         k0(t)
         k1(t)
         k2(t)
         k3(t)
-        k4(t) #[unit = u"ppb^-1*s^-1"]
+        k4(t)
         kx(t), [unit = u"ppb^-1*s^-1"]
         k(t), [unit = u"ppb^-1*s^-1"]
     end
-    C = num_density * ppb_unit  # molec/cm³ → ppb
+    C = num_density * ppb_unit * unit_conv
     eqs = [k0 ~ 2.0E-22 * exp(n) * num_density * num_density_unit_inv
            k1 ~ k0 / 4.3E-1 * (T / T_298)^(-8)
            k2 ~ (k0 / (1.0 + k1)) * 4.1E-1^(1.0 / (1.0 + (log10(k1))^2))
            k3 ~ c0 / (k2 + c0)
            k4 ~ a0 * (x0 - T * y0)
-           kx ~ k4 * exp(b0 / T) * k3 * C * unit_conv
+           kx ~ k4 * exp(b0 / T) * k3 * C
            k ~ max(kx, zero)]
     ODESystem(eqs, t, vars, consts; name = name)
 end

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -6,8 +6,10 @@
     using GasChem, Test
 
     @parameters T=293.0 [unit = u"K"]
-    @parameters num_density = 2.7e19,
-    [unit = u"1/cm^3", description = "Number density of air."]
+    N_A = 6.02214076e23 # Avogadro's number
+    cm3_m3 = 1e6
+    @parameters num_density = 2.7e19 / N_A * cm3_m3,
+    [unit = u"mol/m^3", description = "Number density of air."]
 end
 
 @testitem "constant_k" setup=[RateLawSetup] begin

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -63,7 +63,6 @@ end
     @named base_sys = System(Equation[], t, [], [T, num_density])
     sys = mtkcompile(extend(GasChem.arrhenius_mlc_1(t, T, a0, b0, c0), base_sys))
     prob = ODEProblem(sys, [], (0.0, 3600.0))
-    expected = a0 * exp(c0 / 293.0) * (300.0 / 293.0)^b0
     @test getsym(prob, sys.k)(prob) ≈ 1.793786143019844e-14
 end
 

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -7,7 +7,7 @@
 
     @parameters T=293.0 [unit = u"K"]
     @parameters num_density = 2.7e19,
-    [unit = u"molec/cm^3", description = "Number density of air."]
+    [unit = u"1/cm^3", description = "Number density of air."]
 end
 
 @testitem "constant_k" setup=[RateLawSetup] begin
@@ -89,14 +89,14 @@ end
 end
 
 @testitem "rate_HO2HO2" setup=[RateLawSetup] begin
-    H2O = 1000.0  # ppb
+    @parameters H2O=1000.0, [unit=u"1.0", description="H2O; Water vapor"]
     a0, c0 = 3.00e-13, 460.0
     a1, c1 = 2.1e-33, 920.0
-    @named base_sys = System(Equation[], t, [], [T, num_density])
+    @named base_sys = System(Equation[], t, [], [T, num_density, H2O])
     sys = mtkcompile(extend(GasChem.rate_HO2HO2(t, T, num_density, H2O, a0, c0, a1, c1), base_sys))
     prob = ODEProblem(sys, [], (0.0, 3600.0))
     k_val = getsym(prob, sys.k)(prob)
-    @test k_val ≈ 0
+    @test k_val ≈ 0.07430493859316299
 end
 
 @testitem "rate_OHCO" setup=[RateLawSetup] begin
@@ -173,7 +173,7 @@ end
     sys = mtkcompile(extend(GasChem.eq_const(t, T, num_density, a0, c0, a1, b1, a2, b2, fv), base_sys))
     prob = ODEProblem(sys, [], (0.0, 3600.0))
     k_val = getsym(prob, sys.k)(prob)
-    @test k_val ≈ 0
+    @test k_val ≈ 2.1206340759025532e-27
 end
 
 @testitem "eq_const_1" setup=[RateLawSetup] begin
@@ -252,15 +252,6 @@ end
     @test k_val ≈ 3.567255335036053e-5
 end
 
-@testitem "arrplus_mlc" setup=[RateLawSetup] begin
-    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 0.0, 1.0, 0.0
-    @named base_sys = System(Equation[], t, [], [T, num_density])
-    sys = mtkcompile(extend(GasChem.arrplus_mlc(t, T, a0, b0, c0, d0, e0), base_sys))
-    prob = ODEProblem(sys, [], (0.0, 3600.0))
-    k_val = getsym(prob, sys.k)(prob)
-    @test k_val ≈ 0
-end
-
 @testitem "arrplus_mlc_1" setup=[RateLawSetup] begin
     a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 0.0, 1.0, 0.0
     @named base_sys = System(Equation[], t, [], [T, num_density])
@@ -277,15 +268,6 @@ end
     prob = ODEProblem(sys, [], (0.0, 3600.0))
     k_val = getsym(prob, sys.k)(prob)
     @test k_val ≈ 0.009764682205778403
-end
-
-@testitem "tunplus_mlc" setup=[RateLawSetup] begin
-    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 1.0e8, 1.0, 0.0
-    @named base_sys = System(Equation[], t, [], [T, num_density])
-    sys = mtkcompile(extend(GasChem.tunplus_mlc(t, T, a0, b0, c0, d0, e0), base_sys))
-    prob = ODEProblem(sys, [], (0.0, 3600.0))
-    k_val = getsym(prob, sys.k)(prob)
-    @test k_val ≈ 0
 end
 
 @testitem "tunplus_mlc_1" setup=[RateLawSetup] begin

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -1,0 +1,375 @@
+@testsnippet RateLawSetup begin
+    using DynamicQuantities
+    using SymbolicIndexingInterface: getsym
+    using SciMLBase: ODEProblem
+    using ModelingToolkit: t, @parameters, mtkcompile, System, Equation, @named, extend
+    using GasChem, Test
+
+    @parameters T=293.0 [unit = u"K"]
+    @parameters num_density = 2.7e19,
+    [unit = u"molec/cm^3", description = "Number density of air."]
+end
+
+@testitem "constant_k" setup=[RateLawSetup] begin
+    c = 1.8e-12
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.constant_k(t, T, num_density, c), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 0.0486
+end
+
+@testitem "constant_k_1" setup=[RateLawSetup] begin
+    c = 1.8e-12
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.constant_k_1(t, c), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 1.8e-12
+end
+
+@testitem "regress_T" setup=[RateLawSetup] begin
+    a_0, b_0, T_0 = 1.33e-13, 3.82e-11, -2000.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.regress_T(t, T, num_density, a_0, b_0, T_0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 0.004710333943456039
+end
+
+@testitem "arrhenius_ppb" setup=[RateLawSetup] begin
+    a0, b0, c0 = 3.00e-12, 0.0, -1500.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrhenius_ppb(t, T, num_density, a0, b0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 0.00048432225861535784
+end
+
+@testitem "arrhenius_ppb_3" setup=[RateLawSetup] begin
+    a0, b0, c0 = 2.90e-16, 0.0, -1000.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrhenius_ppb_3(t, T, num_density, a0, b0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 6964.52977737289
+end
+
+@testitem "arrhenius_mlc_SI" setup=[RateLawSetup] begin
+    a0, b0, c0 = 3.00e-12, 0.0, -1500.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrhenius_mlc_SI(t, T, a0, b0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    @test getsym(prob, sys.k)(prob) ≈ 1.7937861430198436e-20
+end
+
+@testitem "arrhenius_mlc_1" setup=[RateLawSetup] begin
+    a0, b0, c0 = 3.00e-12, 0.0, -1500.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrhenius_mlc_1(t, T, a0, b0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    expected = a0 * exp(c0 / 293.0) * (300.0 / 293.0)^b0
+    @test getsym(prob, sys.k)(prob) ≈ 1.793786143019844e-14
+end
+
+@testitem "arr_3rdbody" setup=[RateLawSetup] begin
+    a1, b1, c1 = 6.90e-31, 1.0, 0.0
+    a2, b2, c2 = 2.6e-11, 0.0, 0.0
+    fv = 0.6
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arr_3rdbody(t, T, num_density, a1, b1, c1, a2, b2, c2, fv), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.17987080444910986
+end
+
+@testitem "arr_3rdbody_1" setup=[RateLawSetup] begin
+    a1, b1, c1 = 6.90e-31, 1.0, 0.0
+    a2, b2, c2 = 2.6e-11, 0.0, 0.0
+    fv = 0.6
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arr_3rdbody_1(t, T, num_density, a1, b1, c1, a2, b2, c2, fv), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 6.661881646263328e-18
+end
+
+@testitem "rate_HO2HO2" setup=[RateLawSetup] begin
+    H2O = 1000.0  # ppb
+    a0, c0 = 3.00e-13, 460.0
+    a1, c1 = 2.1e-33, 920.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_HO2HO2(t, T, num_density, H2O, a0, c0, a1, c1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0
+end
+
+@testitem "rate_OHCO" setup=[RateLawSetup] begin
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_OHCO(t, T, num_density), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.006602767113875056
+end
+
+@testitem "rate_RO2NO_a1" setup=[RateLawSetup] begin
+    a0, c0 = 2.80e-12, 300.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_RO2NO_a1(t, T, num_density, a0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 6.314124896654882e-5
+end
+
+@testitem "rate_RO2NO_b1" setup=[RateLawSetup] begin
+    a0, c0 = 2.80e-12, 300.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_RO2NO_b1(t, T, num_density, a0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.21040768863952958
+end
+
+@testitem "rate_RO2NO_a2" setup=[RateLawSetup] begin
+    a0, c0, a1 = 2.60e-12, 365.0, 2.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_RO2NO_a2(t, T, num_density, a0, c0, a1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.006257279178031173
+end
+
+@testitem "rate_RO2NO_b2" setup=[RateLawSetup] begin
+    a0, c0, a1 = 2.60e-12, 365.0, 2.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_RO2NO_b2(t, T, num_density, a0, c0, a1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.2377217070157082
+end
+
+@testitem "tbranch" setup=[RateLawSetup] begin
+    a0, b0, c0 = 9.50e-14, 0.0, 390.0
+    a1, b1, c1 = 2.62e1, 0.0, -1130.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.tbranch(t, T, num_density, a0, b0, c0, a1, b1, c1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.006248197805954408
+end
+
+@testitem "rate_OHHNO3" setup=[RateLawSetup] begin
+    a0, c0 = 2.41e-14, 460.0
+    a1, c1 = 6.51e-34, 1335.0
+    a2, c2 = 2.69e-17, 2199.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_OHHNO3(t, T, num_density, a0, c0, a1, c1, a2, c2), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.0031275792345493445
+end
+
+@testitem "eq_const" setup=[RateLawSetup] begin
+    a0, c0 = 4.90e-03, 12100.0
+    a1, b1 = 9.70e-29, 5.6
+    a2, b2 = 9.3e-12, 1.5
+    fv = 0.6
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.eq_const(t, T, num_density, a0, c0, a1, b1, a2, b2, fv), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0
+end
+
+@testitem "eq_const_1" setup=[RateLawSetup] begin
+    a0, c0 = 4.90e-03, 12100.0
+    a1, b1 = 9.70e-29, 5.6
+    a2, b2 = 9.3e-12, 1.5
+    fv = 0.6
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.eq_const_1(t, T, num_density, a0, c0, a1, b1, a2, b2, fv), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 2.1206340759025532e-27
+end
+
+@testitem "rate_RO2HO2" setup=[RateLawSetup] begin
+    a0, c0, a1 = 2.91e-13, 1300.0, 4.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_RO2HO2(t, T, num_density, a0, c0, a1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.4147862847681038
+end
+
+@testitem "rate_GLYCOH_a" setup=[RateLawSetup] begin
+    a0 = 3.1e-12
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_GLYCOH_a(t, T, num_density, a0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.06695598252070009
+end
+
+@testitem "rate_GLYCOH_b" setup=[RateLawSetup] begin
+    a0 = 3.1e-12
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_GLYCOH_b(t, T, num_density, a0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.016744017479299923
+end
+
+@testitem "rate_HACOH_a" setup=[RateLawSetup] begin
+    a0, c0 = 3.15e-14, 920.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_HACOH_a(t, T, num_density, a0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.01612257331622036
+end
+
+@testitem "rate_HACOH_b" setup=[RateLawSetup] begin
+    a0, c0 = 3.15e-14, 920.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_HACOH_b(t, T, num_density, a0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.0035259242069770776
+end
+
+@testitem "rate_DMSOH" setup=[RateLawSetup] begin
+    a0, c0 = 1.12e-11, -250.0
+    a1, c1 = 3.00e-31, 4020.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_DMSOH(t, T, num_density, a0, c0, a1, c1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 7.287375473764786e17
+end
+
+@testitem "rate_GLYXNO3" setup=[RateLawSetup] begin
+    a0, c0 = 1.4e-12, -1900.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_GLYXNO3(t, T, num_density, a0, c0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 3.567255335036053e-5
+end
+
+@testitem "arrplus_mlc" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 0.0, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrplus_mlc(t, T, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0
+end
+
+@testitem "arrplus_mlc_1" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 0.0, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrplus_mlc_1(t, T, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 3.6165489651031117e-13
+end
+
+@testitem "arrplus_ppb" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 0.0, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.arrplus_ppb(t, T, num_density, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.009764682205778403
+end
+
+@testitem "tunplus_mlc" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 1.0e8, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.tunplus_mlc(t, T, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0
+end
+
+@testitem "tunplus_mlc_1" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 1.0e8, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.tunplus_mlc_1(t, T, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 1.473210332683109e-10
+end
+
+@testitem "tunplus_ppb" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0 = 1.0e-12, 298.0, 1.0e8, 1.0, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.tunplus_ppb(t, T, num_density, a0, b0, c0, d0, e0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 3.977667898244395
+end
+
+@testitem "rate_ISO1" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0, f0, g0 = 1.0e-11, 390.0, 0.3, 1.0, 380.0, 1.0, 380.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_ISO1(t, T, num_density, a0, b0, c0, d0, e0, f0, g0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.7210220267414859
+end
+
+@testitem "rate_ISO2" setup=[RateLawSetup] begin
+    a0, b0, c0, d0, e0, f0, g0 = 1.0e-11, 390.0, 0.3, 1.0, 380.0, 1.0, 380.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_ISO2(t, T, num_density, a0, b0, c0, d0, e0, f0, g0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.3009403732544113
+end
+
+@testitem "rate_EPO" setup=[RateLawSetup] begin
+    a1, e1, m1 = 1.0e-11, 390.0, 1.5e-4
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_EPO(t, T, num_density, a1, e1, m1), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 2.523363950607153e-16
+end
+
+@testitem "rate_PAN_abab" setup=[RateLawSetup] begin
+    a0, b0 = 4.9e-3, 12100.0
+    a1, b1 = 5.4e16, -13830.0
+    cf = 0.3
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_PAN_abab(t, T, num_density, a0, b0, a1, b1, cf), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.00017076882173869417
+end
+
+@testitem "rate_PAN_acac" setup=[RateLawSetup] begin
+    a0, c0 = 9.0e-28, 8.9
+    a1, c1 = 7.7e-12, 0.2
+    cf = 0.6
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_PAN_acac(t, T, num_density, a0, c0, a1, c1, cf), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.1981654191522894
+end
+
+@testitem "rate_NIT" setup=[RateLawSetup] begin
+    a0, b0, c0, n, x0, y0 = 2.9e-12, 350.0, 0.08, 1.0, 8.1e-4, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_NIT(t, T, num_density, a0, b0, c0, n, x0, y0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 2.5119154809815447e-5
+end
+
+@testitem "rate_ALK" setup=[RateLawSetup] begin
+    a0, b0, c0, n, x0, y0 = 2.9e-12, 350.0, 0.08, 1.0, 8.1e-4, 0.0
+    @named base_sys = System(Equation[], t, [], [T, num_density])
+    sys = mtkcompile(extend(GasChem.rate_ALK(t, T, num_density, a0, b0, c0, n, x0, y0), base_sys))
+    prob = ODEProblem(sys, [], (0.0, 3600.0))
+    k_val = getsym(prob, sys.k)(prob)
+    @test k_val ≈ 0.00018517572785290386
+end

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -87,7 +87,7 @@ end
     sys = mtkcompile(extend(GasChem.arr_3rdbody_1(t, T, num_density, a1, b1, c1, a2, b2, c2, fv), base_sys))
     prob = ODEProblem(sys, [], (0.0, 3600.0))
     k_val = getsym(prob, sys.k)(prob)
-    @test k_val ≈ 6.661881646263328e-18
+    @test k_val ≈ 6.661881646263327e-12
 end
 
 @testitem "rate_HO2HO2" setup=[RateLawSetup] begin

--- a/test/geoschem_test.jl
+++ b/test/geoschem_test.jl
@@ -10,8 +10,8 @@ end
 
 # Unit Test 0: Base case
 @testitem "Base case" setup=[GEOSChemGasPhaseSetup] begin
-    u_0 = [6.748699799890642e-7, 2391.7636911471445, 7.959064698668025,
-        -1.0e-323, 4.077796381700777e-6, 5.1356378937680525, 286.178591326171]
+    u_0 = [3.833601143657688e-6, 2.565590651065059, 4.741655927949206, 
+           4.0e-323, 2.12451928742871e-5, 5.111538549832941, 203.66003431702717]
 
     vals = ModelingToolkit.get_defaults(sys)
     for k in setdiff(unknowns(sys), keys(vals))
@@ -27,7 +27,7 @@ end
 
 # Unit Test 1: O1D sensitivity to O3
 @testitem "O1D sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
-    u_1 = -2.831863778346037e-7
+    u_1 = 1.6797552256348174e-8
 
     vals = ModelingToolkit.get_defaults(sys)
     @unpack O3, O1D = sys
@@ -43,7 +43,7 @@ end
 
 # Unit Test 2: OH sensitivity to O3
 @testitem "OH sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
-    u_2 = 1.40349374252692e-5
+    u_2 = 1.382042082942887e-6
 
     vals = ModelingToolkit.get_defaults(sys)
     @unpack O3, OH = sys
@@ -59,7 +59,7 @@ end
 
 # Unit Test 3: NO2 sensitivity to O3
 @testitem "NO2 sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
-    u_3 = 0.0001180509193888908
+    u_3 =  -3.4336010807325956e-7
 
     vals = ModelingToolkit.get_defaults(sys)
     @unpack O3, NO2 = sys
@@ -75,7 +75,7 @@ end
 
 # Unit Test 4: HO2 sensitivity to O3
 @testitem "HO2 sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
-    u_4 = 9.164497264477353e-8
+    u_4 = 2.4732115224621195e-7
 
     vals = ModelingToolkit.get_defaults(sys)
     @unpack O3, HO2 = sys


### PR DESCRIPTION
[0001-Fix-unit-geoschem_ratelaws_test.jl.patch](https://github.com/user-attachments/files/22055383/0001-Fix-unit-geoschem_ratelaws_test.jl.patch)

This PR builds on #151 (gc_si_units) to fix test failures by:

- Delete [the tool functions](https://github.com/EarthSciML/GasChem.jl/pull/127#issuecomment-3110593407) that are expected to be failed unless the unit bug is fixed 
- Remove the `molec` unit of `num_density` in `geoschem_ratelaws_test.jl`, in case the error `ArgumentError: Symbol molec not found in Units or Constants` during test
- Correct the constant declaration of `function eq_const(...)` in `geoschem_ratelaws.jl`