### PR TITLE
Use [sources] for Catalyst.jl master, update to MTK v11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,16 +20,19 @@ EarthSciData = "a293c155-435f-439d-9c11-a083b6b47337"
 [extensions]
 EarthSciDataExt = "EarthSciData"
 
+[sources]
+Catalyst = {url = "https://github.com/SciML/Catalyst.jl.git", rev = "master"}
+
 [compat]
 AllocCheck = "0.2"
 BSON = "0.3.9"
-Catalyst = "16"
+Catalyst = "15"
 DocStringExtensions = "0.9.5"
 DynamicQuantities = "1"
-EarthSciData = "0.14"
-EarthSciMLBase = "0.24"
+EarthSciData = "0.15"
+EarthSciMLBase = "0.25"
 Interpolations = "0.16"
-ModelingToolkit = "10"
+ModelingToolkit = "11"
 OrdinaryDiffEqRosenbrock = "1.10.1"
 SciMLBase = "2.114.0"
 StaticArrays = "1.9"

--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -288,18 +288,18 @@ function SuperFast(; name = :SuperFast, rxn_sys = false)
         jH2COb, CH2O --> CO
         jCH3OOH, CH3OOH --> CH2O + HO2 + OH
     end
-    rxns = compose(rx_sys, rate_systems)
     if rxn_sys
-        return rxns
+        return compose(rx_sys, [ReactionSystem(sys; name = nameof(sys)) for sys in rate_systems])
     end
     # We set `combinatoric_ratelaws=false` because we are modeling macroscopic rather than microscopic behavior.
     # See [here](https://docs.juliahub.com/ModelingToolkit/Qmdqu/3.14.0/systems/ReactionSystem/#ModelingToolkit.oderatelaw)
     # and [here](https://github.com/SciML/Catalyst.jl/issues/311).
-    convert(
-        Catalyst.ReactionRateSystem,
-        complete(rxns);
+    # Convert the reaction system to ODE, then compose with rate subsystems at the ODE level.
+    ode_sys = Catalyst.ode_model(
+        complete(rx_sys);
         combinatoric_ratelaws = false,
         name = name,
-        metadata = Dict(CoupleType => SuperFastCoupler)
+        metadata = Dict(CoupleType => SuperFastCoupler),
     )
+    compose(ode_sys, rate_systems)
 end

--- a/src/geoschem_fullchem.jl
+++ b/src/geoschem_fullchem.jl
@@ -2845,15 +2845,15 @@ function GEOSChemGasPhase(; name = :GEOSChemGasPhase, rxn_sys = false)
         j_165, BENZP --> BENZO#==2021/09/29; Bates2021b; KHB,MSL==#
         j_166, NPHEN --> HNO2 + CO + CO2 + AROMP4 + HO2#==2021/09/29; Bates2021b; KHB,MSL==#
     end
-    rxns = compose(rx_sys, rate_systems)
     if rxn_sys
-        return rxns
+        return compose(rx_sys, [ReactionSystem(sys; name = nameof(sys)) for sys in rate_systems])
     end
-    sys = convert(
-        Catalyst.ReactionRateSystem,
-        complete(rxns),
+    # Convert the reaction system to ODE, then compose with rate subsystems at the ODE level.
+    ode_sys = Catalyst.ode_model(
+        complete(rx_sys);
         combinatoric_ratelaws = false,
         name = name,
-        metadata = Dict(CoupleType => GEOSChemGasPhaseCoupler)
+        metadata = Dict(CoupleType => GEOSChemGasPhaseCoupler),
     )
+    compose(ode_sys, rate_systems)
 end

--- a/test/geoschem_test.jl
+++ b/test/geoschem_test.jl
@@ -6,6 +6,22 @@
     tspan = (0.0, 360.0)
     sys = GEOSChemGasPhase()
     sys = mtkcompile(sys)
+
+    # Helper to replace removed ModelingToolkit.get_defaults in MTK v11
+    function _get_defaults(sys)
+        d = Dict{Any,Any}()
+        for v in unknowns(sys)
+            if ModelingToolkit.hasdefault(v)
+                d[v] = ModelingToolkit.getdefault(v)
+            end
+        end
+        for p in parameters(sys)
+            if ModelingToolkit.hasdefault(p)
+                d[p] = ModelingToolkit.getdefault(p)
+            end
+        end
+        return d
+    end
 end
 
 # Unit Test 0: Base case
@@ -13,7 +29,7 @@ end
     u_0 = [19.995176711847932, 0.002380578760821661, 0.0, 9.428652108253236e-251, 
     5.879149823894928e-6, 0.0, 1.840000000235526e7]
 
-    vals = ModelingToolkit.get_defaults(sys)
+    vals = _get_defaults(sys)
     for k in setdiff(unknowns(sys), keys(vals))
         vals[k] = 0 # Set variables with no default to zero.
     end
@@ -29,7 +45,7 @@ end
 @testitem "O1D sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
     u_1 = 8.160593694128693e-7
 
-    vals = ModelingToolkit.get_defaults(sys)
+    vals = _get_defaults(sys)
     @unpack O3, O1D = sys
     vals[O3] = 20
     vals[O1D] = 1E-6
@@ -45,7 +61,7 @@ end
 @testitem "OH sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
     u_2 = 8.209088520061414e-9
 
-    vals = ModelingToolkit.get_defaults(sys)
+    vals = _get_defaults(sys)
     @unpack O3, OH = sys
     vals[O3] = 20
     vals[OH] = 4E-6
@@ -61,7 +77,7 @@ end
 @testitem "NO2 sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
     u_3 =  1.1784680253867919e-7
 
-    vals = ModelingToolkit.get_defaults(sys)
+    vals = _get_defaults(sys)
     @unpack O3, NO2 = sys
     vals[O3] = 20
     vals[NO2] = 4E-4
@@ -77,7 +93,7 @@ end
 @testitem "HO2 sensitivity to O3" setup=[GEOSChemGasPhaseSetup] begin
     u_4 = 1.6049252593575147e-8
 
-    vals = ModelingToolkit.get_defaults(sys)
+    vals = _get_defaults(sys)
     @unpack O3, HO2 = sys
     vals[O3] = 20
     vals[HO2] = 4E-6


### PR DESCRIPTION
## Summary
- Add `[sources]` section to Project.toml to pull Catalyst.jl from its git master branch (pre-release v15)
- Update compat entries: Catalyst 15, ModelingToolkit 11, EarthSciMLBase 0.25, EarthSciData 0.15
- Replace removed `Catalyst.ReactionRateSystem` with `Catalyst.ode_model` in SuperFast.jl and geoschem_fullchem.jl
- Compose rate subsystems at ODE level (Catalyst v15 only allows `ReactionSystem` to compose with `ReactionSystem`)
- Fix `geoschem_test.jl` to use `hasdefault`/`getdefault` instead of removed `ModelingToolkit.get_defaults`

## Test status
- **superfast_test.jl**: 5/5 pass
- **geoschem_ratelaws_test.jl**: 37/37 pass  
- **geoschem_test.jl**: "Compose GEOSChem FastJX" 64/64 pass; "Base case" and sensitivity tests fixed (replaced `get_defaults`)
- **compose_fastjx_superfast_test.jl**: 2 errors — caused by EarthSciMLBase's `param_to_var`/`copy_with_change` losing subsystem structure with MTK v11 composed systems. Needs upstream fix in EarthSciMLBase.
- **EarthSciData_test.jl**: 2 errors — unit validation issues in coupling (upstream)
- **fastjx_test.jl**: 1 error — Symbolics type mismatch in Direct Flux test (upstream)

## Test plan
- [x] Core SuperFast chemistry tests pass
- [x] GEOSChem rate law tests pass
- [x] GEOSChem FastJX coupling test passes
- [ ] Coupling tests need upstream EarthSciMLBase fix for `copy_with_change` with composed systems in MTK v11

🤖 Generated with [Claude Code](https://claude.com/claude-code)