### PR TITLE
Ignore patch and minor updates of crate-ci/typos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "crate-ci/typos"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary
- Configure dependabot to ignore patch and minor version updates of `crate-ci/typos`, reducing noise from frequent typos action releases that don't require immediate adoption.

## Test plan
- [ ] Verify the YAML syntax is valid
- [ ] Confirm dependabot no longer opens PRs for patch/minor typos updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)