### PR TITLE
rate_ALK: fix k1 temperature-exponent parenthesization (F90 alignment) + test

### DIFF
--- a/src/geoschem_ratelaws.jl
+++ b/src/geoschem_ratelaws.jl
@@ -1221,7 +1221,7 @@ function rate_ALK(t, T, num_density, a0, b0, c0, n, x0, y0; name = :rate_ALK)
     C = num_density * ppb_unit * unit_conv
     eqs = [
         k0 ~ 2.0e-22 * exp(n) * num_density * num_density_unit_inv
-        k1 ~ k0 / 4.3e-1 * (T / T_298)^(-8)
+        k1 ~ k0 / (4.3e-1 * (T / T_298)^(-8))
         k2 ~ (k0 / (1.0 + k1)) * 4.1e-1^(1.0 / (1.0 + (log10(k1))^2))
         k3 ~ c0 / (k2 + c0)
         k4 ~ a0 * (x0 - T * y0)

--- a/test/geoschem_ratelaws_test.jl
+++ b/test/geoschem_ratelaws_test.jl
@@ -331,5 +331,13 @@ end
     sys, k_var = compile_rate_law(GasChem.rate_ALK(t, T, num_density, a0, b0, c0, n, x0, y0))
     prob = ODEProblem(sys, [], (0.0, 3600.0))
     k_val = getsym(prob, k_var)(prob)
-    @test k_val ≈ 0.00018517572785290386
+    # Expected value reflects the corrected rate_ALK temperature-exponent
+    # parenthesization (matches GEOS-Chem fullchem_RateLawFuncs.F90 GC_ALK).
+    @test k_val ≈ 0.00018430587467471127
+    # Cold-temperature branch: pins the k1 grouping k0 / (4.3e-1 * (T / T_298)^(-8)).
+    # The buggy form multiplied the (T / T_298)^(-8) factor instead of dividing it
+    # (effective exponent +8 vs -8), so it diverges as (T/298)^16 away from ~298 K —
+    # ×16.6 in k1 at 250 K, which the single 293 K point above barely exercises (~1.3×).
+    prob_cold = ODEProblem(sys, [T => 250.0], (0.0, 3600.0))
+    @test getsym(prob_cold, k_var)(prob_cold) ≈ 0.00022289914232641306
 end


### PR DESCRIPTION

**bugfix · numerical drift (GEOS-Chem reference alignment)**

## Motivation
Upstream 0.11.2 `src/geoschem_ratelaws.jl` still carries a mis-parenthesized `k1` in `rate_ALK` (~line 1224):

```julia
k1 ~ k0 / 4.3e-1 * (T / T_298)^(-8)        # rate_ALK — buggy
k1 ~ k0 / (4.3e-1 * (T / T_298)^(-8))      # rate_NIT (~line 1162) — correct sibling
```

`/` and `*` bind with equal precedence, so the buggy form **multiplies** by the temperature factor instead of dividing — effectively flipping the exponent (+8 ↔ −8) while staying dimensionless, which is why unit checking never caught it. The GEOS-Chem reference (`fullchem_RateLawFuncs.F90`, `GC_ALK` / `GC_NIT` pair) groups the term; the sibling `rate_NIT` in the same file (~line 1162) already matches it — the two rate laws implement the same k1 expression, so upstream is internally inconsistent today.

The existing expected value at `geoschem_ratelaws_test.jl:~335` (`1.85176e-4`) was generated **from the buggy expression**, so the suite is self-consistently green while pinning the wrong value. It also barely exercises the bug: the two groupings differ in k1 by the factor `(T/T_298)^16` — only ~31% at the 293 K test point (~0.5% in the final rate after the k1→k2 saturation), but **16.6× at 250 K**, well inside the tropospheric temperature range where this rate is evaluated.

## Change
- **Impl fix**: `k1 ~ k0 / (4.3e-1 * (T / T_298)^(-8))` — align the grouping with the F90 reference and with `rate_NIT`.
- **Test**: expectation updated to the value recomputed from the corrected (F90) expression (`1.84306e-4 @ 293 K`, vs `1.85176e-4` from the buggy form), and a new **250 K cold assertion** (`2.22899e-4`) that specifically pins the exponent grouping — a mis-parenthesization only diverges strongly away from the ~300 K reference temperature, which the single 293 K point barely exercises (see the 16.6× k1 divergence above).

## Why this departs from the current design
This PR changes both the shipped numerics and an existing expected value. That value is not an independent reference: it was measured against the mis-parenthesized implementation, so keeping it would keep validating the bug. The corrected expectation is recomputed independently from the GEOS-Chem F90 expression, and the same grouping already ships in upstream's own `rate_NIT` — this PR removes an internal inconsistency rather than introducing a new convention.

## Compatibility impact
This is a bugfix: rates built on `rate_ALK` (the RO2+NO alkyl-nitrate branch family) shift toward the GEOS-Chem F90 values — a reference alignment worth a release-note mention. No API change.

## Validation
2/2 pass (293 K corrected expectation + 250 K grouping guard; both recomputed independently from the F90 expression). Full `Pkg.test` green (rc=0) in the upstream environment on this branch.

![rate_ALK buggy vs fixed over 200–320 K, with k1 and final-rate ratio panels](https://cdn.jsdelivr.net/gh/xk-y/GasChem-fork.jl@pr-assets/rate_alk_temperature.png)

**Figure** — buggy vs fixed rate over 200–320 K, plotted from the committed k0→k4 chain with the test's parameters (reproducible from those committed values). The reconstruction reproduces both test reference values to machine precision (1.8430587467471133e-4 @ 293 K, 2.2289914232641309e-4 @ 250 K). Magnitude note the figure makes explicit: the grouping error is a factor of ~16.6 in **k1** at 250 K, but the downstream `k3 = c0/(k2+c0)` saturation damps it to **+5.2% in the final rate** at these test parameters (+12% at 200 K) — so the case for this fix is reference-correctness and internal consistency, not a large magnitude shift at typical conditions.


---

*Part of the coordinated cross-repo update tracked in #225.*

