### PR TITLE
Earth–Sun distance solar-flux factor (SOLFX) for Fast-JX

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -18,3 +18,7 @@ setp = "setp"      # Function from SymbolicIndexingInterface.jl
 
 # Author names from referenced papers
 Jenkin = "Jenkin"  # M. E. Jenkin (atmospheric chemistry researcher)
+
+# GEOS-Chem Earth-Sun distance solar-flux factor (fast_jx_mod.F90 SOLAR_JX / PHOTO_JX)
+SOLF = "SOLF"
+solf = "solf"

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -1053,6 +1053,19 @@ end
 # get information about the type and units of the output.
 cos_solar_zenith_angle(t::DynamicQuantities.Quantity, lat, long) = 1.0
 
+# Earth-Sun distance solar-flux factor (GEOS-Chem fast_jx_mod.F90 SOLAR_JX SOLFX):
+# the +/-3.4% annual variation in top-of-atmosphere actinic flux with Earth-Sun
+# distance. GEOS-Chem applies SOLF = 1 - 0.034*cos((NDAY-172)*2*pi/365) to every
+# wavelength band's TOA flux in PHOTO_JX. `t` here is absolute Unix time (t + t_ref).
+function solar_flux_factor(t)
+    DOY = dayofyear(Dates.unix2datetime(t))
+    return 1.0 - 0.034 * cos((DOY - 172) * 2.0 * pi / 365.0)
+end
+@register_symbolic solar_flux_factor(t)
+
+# Dummy function for unit validation (dimensionless factor).
+solar_flux_factor(t::DynamicQuantities.Quantity) = 1.0
+
 function calc_direct_flux(CSZA, P, i::Int)
     # calculate direct flux attenuation factor
     single_direct_flux_factor = direct_solar_beam_box_singlewavelength(
@@ -1101,14 +1114,17 @@ function fluxvars(sys::System)
 end
 
 # Symbolic equations for actinic flux
-function flux_sys(csa, P)
+function flux_sys(csa, P, solf)
     @constants c_flux = 1.0 [
         unit = u"s^-1",
         description = "Constant actinic flux (for unit conversion)",
     ]
     flux_vals = [calc_direct_flux(csa, P, i) for i in 1:18]
     flux_vars = fluxvars()
-    eqs = flux_vars .~ flux_vals .* c_flux
+    # Scale every band's TOA flux by the Earth-Sun distance factor (GEOS-Chem SOLFX).
+    # `solf` is precomputed at the system level (like `csa`), so this helper takes
+    # the factor, not raw time.
+    eqs = flux_vars .~ flux_vals .* c_flux .* solf
     return System(eqs, t, flux_vars, [c_flux], name = :ActinicFlux)
 end
 
@@ -1358,7 +1374,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_BrCl(t), [unit = u"s^-1"]
     end
 
-    flux = flux_sys(ParentScope(cosSZA), ParentScope(P) / ParentScope(P_unit))
+    flux = flux_sys(ParentScope(cosSZA), ParentScope(P) / ParentScope(P_unit), solar_flux_factor(t + ParentScope(t_ref)))
     flux_vars = fluxvars(flux)
     j_o31D_adj = adjust_j_o31D(ParentScope(T), ParentScope(P), ParentScope(H2O))
 

--- a/src/interpolations_FastJX.jl
+++ b/src/interpolations_FastJX.jl
@@ -53,7 +53,7 @@ flux_interp_18(P, csa) = interpolations_18_const[18](ustrip(P), ustrip(csa))
 @register_symbolic flux_interp_18(P, csa)
 
 # Symbolic equations for actinic flux
-function flux_eqs_interpolation(csa, P)
+function flux_eqs_interpolation(csa, P, solf)
     flux_vals = []
     flux_vars = []
     @constants c_flux = 1.0 [
@@ -76,7 +76,7 @@ function flux_eqs_interpolation(csa, P)
         push!(flux_vals, f)
     end
 
-    return flux_vars, (flux_vars .~ collect(flux_vals) .* c_flux), c_flux # TODO(CT): remove "collect" when https://github.com/SciML/ModelingToolkit.jl/issues/3888 is fixed.
+    return flux_vars, (flux_vars .~ collect(flux_vals) .* c_flux .* solf), c_flux # TODO(CT): remove "collect" when https://github.com/SciML/ModelingToolkit.jl/issues/3888 is fixed.
 end
 
 # Photolysis species exposed by the interpolated Fast-JX, as (name, cross-section
@@ -222,7 +222,7 @@ function FastJX_interpolation_troposphere(
     @variables cosSZA(t) [description = "Cosine of the solar zenith angle"]
     @variables j_o32OH(t) [unit = u"s^-1"]
 
-    flux_vars, fluxeqs, c_flux = flux_eqs_interpolation(cosSZA, P / P_unit)
+    flux_vars, fluxeqs, c_flux = flux_eqs_interpolation(cosSZA, P / P_unit, solar_flux_factor(t + t_ref))
     j_o31D_adj = adjust_j_o31D(ParentScope(T), ParentScope(P), ParentScope(H2O))
 
     # Build the requested j-variables and their cross-section equations.

--- a/test/fastjx_test.jl
+++ b/test/fastjx_test.jl
@@ -249,3 +249,17 @@ end
     @test GasChem.calc_direct_flux(cos_sza, P, 9) ≈ 0.0
     @test GasChem.calc_direct_flux(cos_sza, P, 18) ≈ 4.908683888514731e16
 end
+
+
+@testitem "solar_flux_factor matches GEOS-Chem SOLFX" begin
+    using Dates
+    # SOLF = 1 - 0.034*cos((DOY-172)*2pi/365)  (fast_jx_mod.F90 SOLAR_JX):
+    # minimum at the aphelion-side solstice (DOY 172), maximum near perihelion.
+    t172 = datetime2unix(DateTime(2016, 6, 20, 12))
+    t355 = datetime2unix(DateTime(2016, 12, 20, 12))
+    @test GasChem.solar_flux_factor(t172) ≈ 0.966 atol = 1e-3
+    @test GasChem.solar_flux_factor(t355) ≈ 1.0339 atol = 1e-3
+    # energy-neutral over a full year
+    days = [datetime2unix(DateTime(2016, 1, 1) + Day(d)) for d in 0:364]
+    @test sum(GasChem.solar_flux_factor.(days)) / 365 ≈ 1.0 atol = 2e-3
+end


### PR DESCRIPTION

**bugfix · non-breaking (±3.4% seasonal actinic flux)**

## Motivation
Upstream FastJX holds the top-of-atmosphere flux constant year-round: it omits the Earth–Sun distance correction that the reference Fast-JX implementation applies to every wavelength band (GEOS-Chem `fast_jx_mod.F90` `SOLAR_JX`: `SOLF = 1 - 0.034*cos((DOY-172)*2π/365)`, applied to each band's TOA flux in `PHOTO_JX`). The omission is a systematic seasonal bias in **every** J-value — photolysis is over-lit by ~3.5% around the aphelion-side solstice (DOY 172, where SOLF = 0.966) and under-lit by ~3.3% around perihelion (SOLF = 1.0339) — which propagates into every photolysis-driven quantity (O3 production, OH).

## Change
Multiply every band's TOA flux by `solar_flux_factor(t)` (the exact GEOS-Chem SOLF formula) in **both** flux paths — the full `flux_sys` and the interpolated `FastJX_interpolation` (`flux_eqs_interpolation`) — so the two paths stay mutually consistent. The factor is precomputed at the system level (like `cosSZA`) from absolute time, and is a no-op for unit validation (dimensionless).

## Why this departs from the current design
This modifies the existing flux equations unconditionally rather than adding an opt-in switch — deliberately: the factor is unconditional in Fast-JX/GEOS-Chem, so an opt-in default-off would leave every existing user with the seasonal bias this fixes. The annual mean of the factor is ≈ 1 (energy-neutral), so there is no net annual flux bias; instantaneous J-values shift by at most ±3.4%, and seasonal-mean photolysis shifts by up to that amount — which is exactly the reference behavior being restored.

## Validation
- New test (`fastjx_test.jl`): 0.966 at DOY 172, 1.0339 at DOY 355, annual mean ≈ 1 (energy-neutral) — the three anchor points of the reference formula.
- Full `Pkg.test` green (rc=0) in the upstream environment, including the interpolated-path integration.

## Notes
Release note: photolysis rates gain a ±3.4% seasonal modulation (reference alignment).


---

*Part of the coordinated cross-repo update tracked in #225.*
