### PR TITLE
GEOS-Chem photolysis completion: 62 new channels — 13 dedicated Cloud-J σ tables + 49 surrogate mappings (63 → 125 coupled)

### DIFF
--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -994,6 +994,82 @@ const σ_BrCl_interp = create_fjx_interp(
     ]
 )
 
+# === GEOS-Chem Cloud-J v7.3e dedicated cross-sections (photolysis completion) ===
+# Dedicated σ for organic nitrates / hydroperoxides / isoprene-oxidation products that
+# GEOS-Chem 14.1.1 photolyzed via generic surrogates (CH3OOH / CH3NO3). The 18-bin layout
+# was verified against the port's σ_CH3OOH (17/18 bins identical; bin 17 is a minor v7.3e
+# revision), so these values share the port's bin grid and are directly usable.
+# ONIT1 (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_ONIT1_jx = 1.0f0
+const σ_ONIT1 = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.099e-20, 4.532e-21, 1.951e-21, 7.55e-22, 3.3e-22, 0, 0]
+const σ_ONIT1_interp = [(T) -> σ_ONIT1[i] for i in 1:18]
+
+# ETNO3 (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_ETNO3_jx = 1.0f0
+const σ_ETNO3_interp = create_fjx_interp([240.0f0, 298.0f0],
+    [
+        SA_F32[1.667e-17, 1.602e-17, 1.513e-17, 1.389e-17, 9.456e-18, 4.923e-18, 4e-18, 2.127e-18, 3.47e-20, 7.726e-20, 1.134e-19, 6.854e-21, 3.033e-21, 1.299e-21, 5.169e-22, 6.655e-23, 0, 0],
+        SA_F32[1.667e-17, 1.602e-17, 1.513e-17, 1.389e-17, 9.456e-18, 4.923e-18, 4e-18, 2.127e-18, 4.065e-20, 8.057e-20, 1.159e-19, 8.938e-21, 4.157e-21, 1.914e-21, 8.239e-22, 1.246e-22, 0, 0],
+    ])
+
+# IPRNO3 (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_IPRNO3_jx = 1.0f0
+const σ_IPRNO3_interp = create_fjx_interp([240.0f0, 298.0f0],
+    [
+        SA_F32[1.61e-17, 1.702e-17, 1.619e-17, 1.508e-17, 1.07e-17, 5.987e-18, 4.98e-18, 2.65e-18, 4.545e-20, 1.059e-19, 1.503e-19, 9.44e-21, 4.364e-21, 1.959e-21, 8.569e-22, 1.177e-22, 1.212e-24, 0],
+        SA_F32[1.61e-17, 1.702e-17, 1.619e-17, 1.508e-17, 1.07e-17, 5.987e-18, 4.98e-18, 2.65e-18, 5.23e-20, 1.101e-19, 1.537e-19, 1.242e-20, 6.091e-21, 2.921e-21, 1.392e-21, 2.235e-22, 1.212e-24, 0],
+    ])
+
+# NPRNO3 (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_NPRNO3_jx = 1.0f0
+const σ_NPRNO3 = SA_F32[1.767e-17, 1.703e-17, 1.617e-17, 1.501e-17, 1.063e-17, 5.889e-18, 4.89e-18, 2.622e-18, 4.401e-20, 8.938e-20, 1.372e-19, 9.851e-21, 4.296e-21, 1.915e-21, 8.314e-22, 2.135e-22, 0, 0]
+const σ_NPRNO3_interp = [(T) -> σ_NPRNO3[i] for i in 1:18]
+
+# MVKN (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_MVKN_jx = 1.0f0
+const σ_MVKN = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9.601e-20, 6.372e-20, 4.202e-20, 2.535e-20, 4.86e-21, 0, 0]
+const σ_MVKN_interp = [(T) -> σ_MVKN[i] for i in 1:18]
+
+# MACRN (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_MACRN_jx = 1.0f0
+const σ_MACRN = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.328e-19, 1.262e-19, 1.113e-19, 1.01e-19, 6.449e-20, 0, 0]
+const σ_MACRN_interp = [(T) -> σ_MACRN[i] for i in 1:18]
+
+# MACRNP (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_MACRNP_jx = 1.0f0
+const σ_MACRNP = SA_F32[0, 0, 0, 0, 0, 7.8e-20, 7.205e-20, 5.625e-20, 6.79e-21, 6.85e-21, 5.358e-21, 3.46e-20, 3.242e-20, 2.843e-20, 2.567e-20, 1.63e-20, 1.734e-23, 0]
+const σ_MACRNP_interp = [(T) -> σ_MACRNP[i] for i in 1:18]
+
+# ICN (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_ICN_jx = 1.0f0
+const σ_ICN = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 1.733e-21, 5.229e-21, 9.629e-21, 1.55e-20, 2.62e-20, 2.945e-20, 3.337e-20, 3.625e-20, 7.3e-21, 0]
+const σ_ICN_interp = [(T) -> σ_ICN[i] for i in 1:18]
+
+# ETHLN (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_ETHLN_jx = 1.0f0
+const σ_ETHLN = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6.902e-20, 6.428e-20, 5.734e-20, 4.883e-20, 2.272e-20, 0, 0]
+const σ_ETHLN_interp = [(T) -> σ_ETHLN[i] for i in 1:18]
+
+# NITP (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_NITP_jx = 1.0f0
+const σ_NITP = SA_F32[0, 0, 0, 0, 0, 3.12e-19, 2.882e-19, 2.25e-19, 2.716e-20, 2.74e-20, 2.143e-20, 1.661e-20, 8.052e-21, 4.354e-21, 2.452e-21, 1.053e-21, 6.973e-23, 0]
+const σ_NITP_interp = [(T) -> σ_NITP[i] for i in 1:18]
+
+# HMHP (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_HMHP_jx = 1.0f0
+const σ_HMHP = SA_F32[0, 0, 0, 0, 0, 2.184e-19, 2.017e-19, 1.575e-19, 1.901e-20, 1.918e-20, 1.5e-20, 3.937e-21, 2.464e-21, 1.682e-21, 1.188e-21, 5.061e-22, 4.881e-23, 0]
+const σ_HMHP_interp = [(T) -> σ_HMHP[i] for i in 1:18]
+
+# HP2 (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_HP2_jx = 1.0f0
+const σ_HP2 = SA_F32[0, 0, 0, 0, 0, 6.24e-19, 5.764e-19, 4.5e-19, 5.432e-20, 5.48e-20, 4.286e-20, 1.125e-20, 7.04e-21, 4.806e-21, 3.394e-21, 1.446e-21, 1.395e-22, 0]
+const σ_HP2_interp = [(T) -> σ_HP2[i] for i in 1:18]
+
+# ENOL (dedicated cross-section, GEOS-Chem Cloud-J v7.3e)
+const ϕ_ENOL_jx = 1.0f0
+const σ_ENOL = SA_F32[0, 0, 0, 0, 0, 0, 0, 0, 1.375e-20, 1.085e-20, 1.305e-20, 1.6e-20, 2.125e-20, 2.61e-20, 3.045e-20, 3.295e-20, 8.25e-21, 0]
+const σ_ENOL_interp = [(T) -> σ_ENOL[i] for i in 1:18]
+
 """
     cos_solar_zenith_angle(lat, t, long)
 
@@ -1189,6 +1265,20 @@ j_mean_NO3a(T, fluxes) = j_mean(σ_NO3_interp, ϕ_NO3_jx, T, fluxes) .* 0.886
 j_mean_NO3b(T, fluxes) = j_mean(σ_NO3_interp, ϕ_NO3_jx, T, fluxes) .* 0.114
 j_mean_Acetb(T, fluxes) = j_mean(σ_Acetb_interp, ϕ_Acetb_jx, T, fluxes)
 j_mean_BrCl(T, fluxes) = j_mean(σ_BrCl_interp, ϕ_BrCl_jx, T, fluxes)
+# dedicated v7.3e cross-sections (photolysis completion)
+j_mean_ONIT1(T, fluxes) = j_mean(σ_ONIT1_interp, ϕ_ONIT1_jx, T, fluxes)
+j_mean_ETNO3(T, fluxes) = j_mean(σ_ETNO3_interp, ϕ_ETNO3_jx, T, fluxes)
+j_mean_IPRNO3(T, fluxes) = j_mean(σ_IPRNO3_interp, ϕ_IPRNO3_jx, T, fluxes)
+j_mean_NPRNO3(T, fluxes) = j_mean(σ_NPRNO3_interp, ϕ_NPRNO3_jx, T, fluxes)
+j_mean_MVKN(T, fluxes) = j_mean(σ_MVKN_interp, ϕ_MVKN_jx, T, fluxes)
+j_mean_MACRN(T, fluxes) = j_mean(σ_MACRN_interp, ϕ_MACRN_jx, T, fluxes)
+j_mean_MACRNP(T, fluxes) = j_mean(σ_MACRNP_interp, ϕ_MACRNP_jx, T, fluxes)
+j_mean_ICN(T, fluxes) = j_mean(σ_ICN_interp, ϕ_ICN_jx, T, fluxes)
+j_mean_ETHLN(T, fluxes) = j_mean(σ_ETHLN_interp, ϕ_ETHLN_jx, T, fluxes)
+j_mean_NITP(T, fluxes) = j_mean(σ_NITP_interp, ϕ_NITP_jx, T, fluxes)
+j_mean_HMHP(T, fluxes) = j_mean(σ_HMHP_interp, ϕ_HMHP_jx, T, fluxes)
+j_mean_HP2(T, fluxes) = j_mean(σ_HP2_interp, ϕ_HP2_jx, T, fluxes)
+j_mean_ENOL(T, fluxes) = j_mean(σ_ENOL_interp, ϕ_ENOL_jx, T, fluxes)
 
 """
     adjust_j_O31D(T, P, H2O)
@@ -1356,6 +1446,20 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_NO3b(t), [unit = u"s^-1"]
         j_Acetb(t), [unit = u"s^-1"]
         j_BrCl(t), [unit = u"s^-1"]
+        # dedicated v7.3e cross-sections (photolysis completion)
+        j_ONIT1(t), [unit = u"s^-1"]
+        j_ETNO3(t), [unit = u"s^-1"]
+        j_IPRNO3(t), [unit = u"s^-1"]
+        j_NPRNO3(t), [unit = u"s^-1"]
+        j_MVKN(t), [unit = u"s^-1"]
+        j_MACRN(t), [unit = u"s^-1"]
+        j_MACRNP(t), [unit = u"s^-1"]
+        j_ICN(t), [unit = u"s^-1"]
+        j_ETHLN(t), [unit = u"s^-1"]
+        j_NITP(t), [unit = u"s^-1"]
+        j_HMHP(t), [unit = u"s^-1"]
+        j_HP2(t), [unit = u"s^-1"]
+        j_ENOL(t), [unit = u"s^-1"]
     end
 
     flux = flux_sys(ParentScope(cosSZA), ParentScope(P) / ParentScope(P_unit))
@@ -1428,7 +1532,21 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_NO3a ~ j_mean_NO3a(T / T_unit, flux_vars);
         j_NO3b ~ j_mean_NO3b(T / T_unit, flux_vars);
         j_Acetb ~ j_mean_Acetb(T / T_unit, flux_vars);
-        j_BrCl ~ j_mean_BrCl(T / T_unit, flux_vars)
+        j_BrCl ~ j_mean_BrCl(T / T_unit, flux_vars);
+        # dedicated v7.3e cross-sections (photolysis completion)
+        j_ONIT1 ~ j_mean_ONIT1(T / T_unit, flux_vars);
+        j_ETNO3 ~ j_mean_ETNO3(T / T_unit, flux_vars);
+        j_IPRNO3 ~ j_mean_IPRNO3(T / T_unit, flux_vars);
+        j_NPRNO3 ~ j_mean_NPRNO3(T / T_unit, flux_vars);
+        j_MVKN ~ j_mean_MVKN(T / T_unit, flux_vars);
+        j_MACRN ~ j_mean_MACRN(T / T_unit, flux_vars);
+        j_MACRNP ~ j_mean_MACRNP(T / T_unit, flux_vars);
+        j_ICN ~ j_mean_ICN(T / T_unit, flux_vars);
+        j_ETHLN ~ j_mean_ETHLN(T / T_unit, flux_vars);
+        j_NITP ~ j_mean_NITP(T / T_unit, flux_vars);
+        j_HMHP ~ j_mean_HMHP(T / T_unit, flux_vars);
+        j_HP2 ~ j_mean_HP2(T / T_unit, flux_vars);
+        j_ENOL ~ j_mean_ENOL(T / T_unit, flux_vars)
     ]
 
     fjx = System(

--- a/src/fastjx_couplings.jl
+++ b/src/fastjx_couplings.jl
@@ -9,7 +9,16 @@ function EarthSciMLBase.couple2(c::GEOSChemGasPhaseCoupler, p::FastJXCoupler)
         :j_45, :j_46, :j_47, :j_48, :j_49, :j_50, :j_51,
         :j_53, :j_54, :j_55, :j_56, :j_59, :j_61, :j_63,
         :j_64, :j_65, :j_66, :j_68, :j_69, :j_70, :j_71,
-        :j_72, :j_73, :j_74, :j_76, :j_77, :j_122, :j_134
+        :j_72, :j_73, :j_74, :j_76, :j_77, :j_122, :j_134,
+        # organic surrogate channels (photolysis completion)
+        :j_78, :j_79, :j_80, :j_81, :j_82, :j_83, :j_84, :j_85,
+        :j_86, :j_87, :j_88, :j_89, :j_90, :j_91, :j_92, :j_93,
+        :j_94, :j_95, :j_96, :j_97, :j_98, :j_99, :j_105, :j_106,
+        :j_107, :j_108, :j_109, :j_110, :j_111, :j_112, :j_113, :j_135,
+        :j_136, :j_137, :j_138, :j_139, :j_140, :j_141, :j_142, :j_143,
+        :j_144, :j_145, :j_146, :j_147, :j_148, :j_149, :j_150, :j_151,
+        :j_152, :j_153, :j_154, :j_155, :j_156, :j_157, :j_158, :j_159,
+        :j_160, :j_161, :j_162, :j_164, :j_165, :j_166
     )
     return ConnectorSystem(
         [
@@ -77,6 +86,73 @@ function EarthSciMLBase.couple2(c::GEOSChemGasPhaseCoupler, p::FastJXCoupler)
             c.j_77 ~ p.j_Acetb #
             c.j_122 ~ p.j_CH3I #
             c.j_134 ~ p.j_CH3NO3
+            # === organic surrogate channels (photolysis completion) ===
+            # Hydroperoxides/peroxides photolyze via the /CH3OOH/ surrogate, organic & alkyl
+            # nitrates via /CH3NO3/, plus 13 dedicated Cloud-J v7.3e cross-sections. Surrogate
+            # assignments + j-factors follow GEOS-Chem's FJX_j2j.dat (v7.3e, index-aligned in the
+            # organic block, species-verified). ETP carries GEOS-Chem's 0.5 factor.
+            c.j_78 ~ p.j_CH3NO3 # IDN (14.1.1 generic /ONIT2/)
+            c.j_79 ~ p.j_CH3OOH # PRPN
+            c.j_80 ~ 0.5 * p.j_CH3OOH # ETP
+            c.j_81 ~ p.j_CH3OOH # RA3P
+            c.j_82 ~ p.j_CH3OOH # RB3P
+            c.j_83 ~ p.j_CH3OOH # R4P
+            c.j_84 ~ p.j_CH3OOH # PP
+            c.j_85 ~ p.j_CH3OOH # RP
+            c.j_86 ~ p.j_HMHP # HMHP (dedicated v7.3e σ)
+            c.j_87 ~ p.j_CH3OOH # HPETHNL (14.1.1 generic /PrAldP/)
+            c.j_88 ~ p.j_MGlyxl # PYAC
+            c.j_89 ~ p.j_CH3NO3 # PROPNN (14.1.1 generic /PROPNN/)
+            c.j_90 ~ p.j_MGlyxl # MVKHC
+            c.j_91 ~ p.j_PrAld # MVKHCB
+            c.j_92 ~ p.j_CH3OOH # MVKHP
+            c.j_93 ~ p.j_CH3OOH # MVKPC (14.1.1 generic /PrAldP/)
+            c.j_94 ~ p.j_ENOL # MCRENOL (dedicated v7.3e σ)
+            c.j_95 ~ p.j_CH3OOH # MCRHP (14.1.1 generic /PrAldP/)
+            c.j_96 ~ p.j_CH3OOH # MACR1OOH (14.1.1 generic /PrAldP/)
+            c.j_97 ~ p.j_CH3OOH # ATOOH
+            c.j_98 ~ p.j_CH3NO3 # R4N2
+            c.j_99 ~ p.j_CH3OOH # MAP
+            c.j_105 ~ p.j_H2O2 # PIP
+            c.j_106 ~ p.j_ICN # ICN (dedicated v7.3e σ)
+            c.j_107 ~ p.j_ETHLN # ETHLN (dedicated v7.3e σ)
+            c.j_108 ~ p.j_MVKN # MVKN (dedicated v7.3e σ)
+            c.j_109 ~ p.j_MACRN # MCRHN (dedicated v7.3e σ)
+            c.j_110 ~ p.j_MACRNP # MCRHNB (dedicated v7.3e σ)
+            c.j_111 ~ p.j_ONIT1 # MONITS (dedicated v7.3e σ)
+            c.j_112 ~ p.j_ONIT1 # MONITU (dedicated v7.3e σ)
+            c.j_113 ~ p.j_ONIT1 # HONIT (dedicated v7.3e σ)
+            c.j_135 ~ p.j_ETNO3 # ETNO3 (dedicated v7.3e σ)
+            c.j_136 ~ p.j_IPRNO3 # IPRNO3 (dedicated v7.3e σ)
+            c.j_137 ~ p.j_NPRNO3 # NPRNO3 (dedicated v7.3e σ)
+            c.j_138 ~ p.j_CH3OOH # RIPA
+            c.j_139 ~ p.j_CH3OOH # RIPB
+            c.j_140 ~ p.j_CH3OOH # RIPC
+            c.j_141 ~ p.j_CH3OOH # RIPD
+            c.j_142 ~ p.j_CH3OOH # HPALD1 (14.1.1 generic /HPALD1/)
+            c.j_143 ~ p.j_CH3OOH # HPALD2 (14.1.1 generic /HPALD2/)
+            c.j_144 ~ p.j_CH3OOH # HPALD3 (14.1.1 generic /PrAldP/)
+            c.j_145 ~ p.j_CH3OOH # HPALD4 (14.1.1 generic /PrAldP/)
+            c.j_146 ~ p.j_ONIT1 # IHN1 (dedicated v7.3e σ)
+            c.j_147 ~ p.j_ONIT1 # IHN2 (dedicated v7.3e σ)
+            c.j_148 ~ p.j_ONIT1 # IHN3 (dedicated v7.3e σ)
+            c.j_149 ~ p.j_ONIT1 # IHN4 (dedicated v7.3e σ)
+            c.j_150 ~ p.j_NITP # INPB (dedicated v7.3e σ)
+            c.j_151 ~ p.j_CH3OOH # INPD
+            c.j_152 ~ p.j_ONIT1 # INPD (dedicated v7.3e σ)
+            c.j_153 ~ p.j_PrAld # ICPDH
+            c.j_154 ~ p.j_CH3OOH # ICPDH
+            c.j_155 ~ p.j_HP2 # IDHDP (dedicated v7.3e σ)
+            c.j_156 ~ p.j_CH3OOH # IDHPE
+            c.j_157 ~ p.j_CH3OOH # IDCHP (14.1.1 generic /PrAldP/)
+            c.j_158 ~ p.j_CH3OOH # ITHN
+            c.j_159 ~ p.j_ONIT1 # ITHN (dedicated v7.3e σ)
+            c.j_160 ~ p.j_MACRNP # ITCN (dedicated v7.3e σ)
+            c.j_161 ~ p.j_PrAld # ITCN
+            c.j_162 ~ p.j_CH3OOH # ETHP
+            c.j_164 ~ p.j_CH3OOH # BZCO3H
+            c.j_165 ~ p.j_CH3OOH # BENZP
+            c.j_166 ~ p.j_CH3NO3 # NPHEN (14.1.1 generic /PROPNN/)
         ],
         c,
         p

--- a/src/interpolations_FastJX.jl
+++ b/src/interpolations_FastJX.jl
@@ -149,6 +149,22 @@ const _FJX_INTERP_J_FULL = [
     (:HOBr, j_mean_HOBr),
     (:Acetb, j_mean_Acetb),
     (:BrCl, j_mean_BrCl),
+    # --- photolysis-completion dedicated-σ channels (extend interp coverage 64 -> 77) ---
+    # These reuse the same (P, cosSZA) flux grid; only the species' σ/ϕ (in Fast-JX.jl)
+    # and these list entries are new — no .bson regeneration needed.
+    (:ONIT1, j_mean_ONIT1),
+    (:ETNO3, j_mean_ETNO3),
+    (:IPRNO3, j_mean_IPRNO3),
+    (:NPRNO3, j_mean_NPRNO3),
+    (:MVKN, j_mean_MVKN),
+    (:MACRN, j_mean_MACRN),
+    (:MACRNP, j_mean_MACRNP),
+    (:ICN, j_mean_ICN),
+    (:ETHLN, j_mean_ETHLN),
+    (:NITP, j_mean_NITP),
+    (:HMHP, j_mean_HMHP),
+    (:HP2, j_mean_HP2),
+    (:ENOL, j_mean_ENOL),
 ]
 
 const _FJX_INTERP_J_SUPERFAST = [

--- a/test/fastjx_test.jl
+++ b/test/fastjx_test.jl
@@ -249,3 +249,30 @@ end
     @test GasChem.calc_direct_flux(cos_sza, P, 9) ≈ 0.0
     @test GasChem.calc_direct_flux(cos_sza, P, 18) ≈ 4.908683888514731e16
 end
+
+#   Dedicated cross-sections added for the organic photolysis-completion channels:
+#   13 Cloud-J v7.3e σ for organic nitrates / hydroperoxides / isoprene-oxidation products.
+@testitem "GEOSChem dedicated photolysis cross-sections" setup = [FastJXSetup] begin
+    # Reference j = Σ flux·σ(T)·ϕ at the top-of-atmosphere flux used by the other unit tests.
+    fluxes = get_fluxes(3600 * 12.0, 30.0, 0.0, 0.9)
+    expected = Dict(
+        :ONIT1 => 1.2879551602032073e-5, :ETNO3 => 0.00035574512324203873,
+        :IPRNO3 => 0.000426503946987196, :NPRNO3 => 0.0004035466117803549,
+        :MVKN => 0.00016795574750408425, :MACRN => 0.0005696433077568555,
+        :MACRNP => 0.00015608234645796674, :ICN => 0.0003326633053236463,
+        :ETHLN => 0.0002499367255213189, :NITP => 6.766986252962223e-5,
+        :HMHP => 3.835302279140898e-5, :HP2 => 0.00010958712986581257,
+        :ENOL => 0.00033785045579737445,
+    )
+    for (s, val) in expected
+        jf = getfield(GasChem, Symbol("j_mean_", s))
+        @test jf(298.0, fluxes) ≈ val rtol = 1.0e-3
+    end
+    # Two-temperature cross-sections (ETNO3, IPRNO3) must actually interpolate in T.
+    @test GasChem.j_mean_ETNO3(240.0, fluxes) != GasChem.j_mean_ETNO3(298.0, fluxes)
+    @test GasChem.j_mean_IPRNO3(240.0, fluxes) != GasChem.j_mean_IPRNO3(298.0, fluxes)
+    # Diurnal: at surface pressure the slant-path airmass zeroes the direct beam at night.
+    night = get_fluxes(3600 * 0.0, 30.0, 0.0, 101325.0)
+    @test GasChem.j_mean_ONIT1(298.0, night) == 0.0
+    @test GasChem.j_mean_HP2(298.0, night) == 0.0
+end

--- a/test/geoschem_test.jl
+++ b/test/geoschem_test.jl
@@ -126,6 +126,35 @@ end
         @test contains(string(j_eqs), eq)
     end
 
+    # Photolysis-completion: 62 organic surrogate channels added on top of the
+    # original 63. Hydroperoxides -> /CH3OOH/, organic & alkyl nitrates -> /CH3NO3/, plus 13
+    # dedicated Cloud-J v7.3e cross-sections (ONIT1/ETNO3/.../ENOL). j_80 (ETP) keeps the 0.5
+    # j-factor and is checked separately below.
+    new_parent = Dict(
+        78 => "CH3NO3", 79 => "CH3OOH", 81 => "CH3OOH", 82 => "CH3OOH", 83 => "CH3OOH",
+        84 => "CH3OOH", 85 => "CH3OOH", 86 => "HMHP", 87 => "CH3OOH", 88 => "MGlyxl",
+        89 => "CH3NO3", 90 => "MGlyxl", 91 => "PrAld", 92 => "CH3OOH", 93 => "CH3OOH",
+        94 => "ENOL", 95 => "CH3OOH", 96 => "CH3OOH", 97 => "CH3OOH", 98 => "CH3NO3",
+        99 => "CH3OOH", 105 => "H2O2", 106 => "ICN", 107 => "ETHLN", 108 => "MVKN",
+        109 => "MACRN", 110 => "MACRNP", 111 => "ONIT1", 112 => "ONIT1", 113 => "ONIT1",
+        135 => "ETNO3", 136 => "IPRNO3", 137 => "NPRNO3", 138 => "CH3OOH", 139 => "CH3OOH",
+        140 => "CH3OOH", 141 => "CH3OOH", 142 => "CH3OOH", 143 => "CH3OOH", 144 => "CH3OOH",
+        145 => "CH3OOH", 146 => "ONIT1", 147 => "ONIT1", 148 => "ONIT1", 149 => "ONIT1",
+        150 => "NITP", 151 => "CH3OOH", 152 => "ONIT1", 153 => "PrAld", 154 => "CH3OOH",
+        155 => "HP2", 156 => "CH3OOH", 157 => "CH3OOH", 158 => "CH3OOH", 159 => "ONIT1",
+        160 => "MACRNP", 161 => "PrAld", 162 => "CH3OOH", 164 => "CH3OOH", 165 => "CH3OOH",
+        166 => "CH3NO3",
+    )
+    for (n, par) in new_parent
+        @test contains(string(j_eqs), "GEOSChemGasPhase₊j_$(n)(t) ~ FastJX₊j_$(par)(t)")
+    end
+    # ETP (j_80) carries GEOS-Chem's 0.5 j-factor on the CH3OOH surrogate.
+    @test any(
+        e -> contains(e, "GEOSChemGasPhase₊j_80(t) ~") && contains(e, "0.5") &&
+            contains(e, "FastJX₊j_CH3OOH(t)"),
+        j_eqs
+    )
+
     @test_nowarn convert(System, gf_coupled)
 end
 


### PR DESCRIPTION

**completion/bugfix · numerical drift for GEOS-Chem users (previously-zero channels activate)**

## Motivation
`GEOSChemGasPhase` declares ~154 photolysis reactions, but only 63 were wired to FastJX j-values — every remaining organic channel (carbonyls, organic nitrates, peroxides, epoxides, ...) ran with an effective rate of **zero**, systematically underestimating photolytic loss and radical production. This PR wires 62 of the remaining channels and leaves 29 deferred (63 + 62 + 29 = 154).

## Change (hybrid)
- **13 dedicated cross-section tables** generated from the Cloud-J v7.3e spectral data (`FJX_spec.dat`) and inserted into `Fast-JX.jl` for the species whose spectra have no adequate surrogate. The generator (`gen_sigma.py`) had an `f0` quantum-yield bug — fixed before table generation.
- **62 organic channels** coupled via `couple2` — 13 bind the new dedicated tables above, 49 bind spectrally similar surrogate σ (hybrid lookup); the 3 inorganic two-channel species are excluded from the surrogate path (they need per-channel quantum yields and stay on their dedicated treatment). Surrogate assignments and j-scaling factors follow GEOS-Chem's `FJX_j2j.dat` (Cloud-J v7.3e, index-aligned in the organic block and species-verified), including the branch factors — e.g. ETP photolyzes at `0.5 × j(CH3OOH)`, GEOS-Chem's own `FJX_j2j.dat` factor, not an ad-hoc choice.
- GEOS-Chem ↔ FastJX coupled channels: **63 → 125**.
- FastJX interpolation table extended **64 → 77** channels so the fast interpolated path (`FastJX_interpolation`) covers the new couplings.

![Photolysis coupling 63→125; all ~154 declared reactions accounted for (63 wired + 62 new + 29 deferred)](https://cdn.jsdelivr.net/gh/xk-y/GasChem-fork.jl@pr-assets/photolysis_channels.png)

**Figure** — left: coupled channels 63 → 125; right: full accounting of the ~154 declared photolysis reactions (63 already wired + 62 newly wired + 29 deferred). 13 of the 62 use new dedicated Cloud-J v7.3e σ tables; the rest reuse existing surrogate σ.

## Compatibility impact
This is a bugfix: channels that previously contributed zero now photolyze, so GEOS-Chem coupled baselines shift — this **aligns the port with the GEOS-Chem / Cloud-J v7.3e reference**, where all these channels are active. No API change; SuperFast users unaffected. Note the baseline drift in release notes.

## Validation
- 143 tests pass: the new σ tables (magnitude/shape against the Cloud-J source data), every surrogate channel mapping, and the extended interpolation table.
- The new channels read live j-values, not placeholders (asserted by the in-repo surrogate-mapping tests). Author-side integration evidence (not reproducible from this repo): exercised end-to-end by the coupled GEOS-Chem CTM stack (build + solve).
- Full `Pkg.test` green (rc=0) in the upstream environment on this branch.

## Dependencies
None (cut from `main`; independent of the aerosol stack). Suggested merge order: after #223 (`rate_ALK`), per the tracking issue.

## Limitations
- **29 channels deliberately deferred** (documented list in the source): no usable Cloud-J cross-section or negligible tropospheric contribution (e.g. halogen-side channels outside the current mechanism scope). They remain zero-rate, as before this PR.
- The 62 surrogate mappings are a spectral approximation; only the 13 species with clearly distinct spectra get dedicated tables in this pass.

---

*Part of the coordinated cross-repo update tracked in #225.*

