### PR TITLE
SuperFast rate_2HO2: make HO2+HO2 water enhancement linear in H2O (was ∝H2O²)

### DIFF
--- a/src/SuperFast.jl
+++ b/src/SuperFast.jl
@@ -125,7 +125,7 @@ function rate_2HO2(t, T, P, H2O, a0, c0, a1, c1; name = :rate_HO2HO2)
         [
             k ~
                 (k0.k + k1.k * num_density_unitless) *
-                (1.0 + 1.4e-21 * H2O * H2O_ppb_molec_cm3 * exp(T_0 / T)),
+                (1.0 + 1.4e-21 * H2O_ppb_molec_cm3 * exp(T_0 / T)),
         ],
         t,
         [k],


### PR DESCRIPTION
## Summary

`rate_2HO2` (the HO₂ + HO₂ → H₂O₂ + O₂ water-vapor enhancement) is **quadratic in H₂O instead of linear**.

Line 119 already builds `[H₂O]` in molec cm⁻³:
```julia
H2O_ppb_molec_cm3 = H2O * ppb_inv * 1.0e-9 * num_density_unitless
```
but the enhancement factor multiplied by `H2O` **again**:
```julia
(1.0 + 1.4e-21 * H2O * H2O_ppb_molec_cm3 * exp(T_0 / T))   # ∝ H2O²
```

In humid surface air this factor evaluates to **~1.9×10⁷** instead of the physical **~2** (water roughly doubles the self-reaction), massively over-producing H₂O₂ and draining HOₓ wherever SuperFast runs in humid air. It is also dimensionally inconsistent (a ppb-unit term added to a dimensionless `1.0`).

The correct JPL/GEOS-Chem form — and this repo's own `rate_HO2HO2` in `geoschem_ratelaws.jl` — is **linear** in H₂O.

## Fix

Drop the extra `H2O *` (the `H2O_ppb_molec_cm3` factor already carries the dependence). One line.

## Verification

Enhancement factor at the surface: **≈2.03** after the fix (physical) vs ≈1.9×10⁷ before; structurally identical to the audited-correct `rate_HO2HO2`. Only SuperFast is affected (the GEOS-Chem mechanism's `rate_HO2HO2` was already correct).

Found by a module-by-module equivalence audit of this stack vs GEOS-Chem Classic 14.7.1. Part of the Stage 6 addendum in #225.