### PR TITLE
Fast-JX: interpolate all 8 pressure-axis cross-sections over P, not T (~2x surface-J inflation on carbonyls)

### DIFF
--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -1145,9 +1145,15 @@ j_mean_MEKeto(T, fluxes) = j_mean(σ_MEKeto_interp, ϕ_MEKeto_jx, T, fluxes)
 j_mean_PAN(T, fluxes) = j_mean(σ_PAN_interp, ϕ_PAN_jx, T, fluxes)
 j_mean_H2402(T, fluxes) = j_mean(σ_H2402_interp, ϕ_H2402_jx, T, fluxes)
 j_mean_PrAld(T, fluxes) = j_mean(σ_PrAld_interp, ϕ_PrAld_jx, T, fluxes)
-j_mean_MeVKa(T, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, T, fluxes) .* 0.6
-j_mean_MeVKb(T, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, T, fluxes) .* 0.2
-j_mean_MeVKc(T, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, T, fluxes) .* 0.2
+# NB: MeVK, Aceta, ActAld and MGlyxl are Fast-JX PRESSURE-interpolated species
+# (FJX_spec.dat rows p177/p566/p999, in hPa; Cloud-J JRATET dispatches these on
+# the SQQ='p' flag and interpolates sigma over mid-layer PRESSURE, not T).
+# Their j_mean wrappers therefore take pressure in hPa; passing temperature
+# evaluated sigma at 'P = T Kelvin hPa' (~288 hPa at the surface), inflating
+# e.g. J_ActAld ~2.4x at 1013 hPa.
+j_mean_MeVKa(p_hPa, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, p_hPa, fluxes) .* 0.6
+j_mean_MeVKb(p_hPa, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, p_hPa, fluxes) .* 0.2
+j_mean_MeVKc(p_hPa, fluxes) = j_mean(σ_MeVK_interp, ϕ_MeVK_jx, p_hPa, fluxes) .* 0.2
 j_mean_ClNO3b(T, fluxes) = j_mean(σ_ClNO3b_interp, ϕ_ClNO3b_jx, T, fluxes)
 j_mean_F113(T, fluxes) = j_mean(σ_F113_interp, ϕ_F113_jx, T, fluxes)
 j_mean_HNO4(T, fluxes) = j_mean(σ_HNO4_interp, ϕ_HNO4_jx, T, fluxes)
@@ -1164,7 +1170,7 @@ j_mean_CCl4(T, fluxes) = j_mean(σ_CCl4_interp, ϕ_CCl4_jx, T, fluxes)
 j_mean_Cl2(T, fluxes) = j_mean(σ_Cl2_interp, ϕ_Cl2_jx, T, fluxes)
 j_mean_CH3I(T, fluxes) = j_mean(σ_CH3I_interp, ϕ_CH3I_jx, T, fluxes)
 j_mean_HNO2(T, fluxes) = j_mean(σ_HNO2_interp, ϕ_HNO2_jx, T, fluxes)
-j_mean_Aceta(T, fluxes) = j_mean(σ_Aceta_interp, ϕ_Aceta_jx, T, fluxes)
+j_mean_Aceta(p_hPa, fluxes) = j_mean(σ_Aceta_interp, ϕ_Aceta_jx, p_hPa, fluxes)
 j_mean_N2O(T, fluxes) = j_mean(σ_N2O_interp, ϕ_N2O_jx, T, fluxes)
 j_mean_MeCCl3(T, fluxes) = j_mean(σ_MeCCl3_interp, ϕ_MeCCl3_jx, T, fluxes)
 j_mean_Cl2O2(T, fluxes) = j_mean(σ_Cl2O2_interp, ϕ_Cl2O2_jx, T, fluxes)
@@ -1175,7 +1181,7 @@ j_mean_Glyxlb(T, fluxes) = j_mean(σ_Glyxlb_interp, ϕ_Glyxlb_jx, T, fluxes)
 j_mean_F141b(T, fluxes) = j_mean(σ_F141b_interp, ϕ_F141b_jx, T, fluxes)
 j_mean_O3(T, fluxes) = j_mean(σ_O3_interp, ϕ_O3_jx, T, fluxes)
 j_mean_ClNO3a(T, fluxes) = j_mean(σ_ClNO3a_interp, ϕ_ClNO3a_jx, T, fluxes)
-j_mean_ActAld(T, fluxes) = j_mean(σ_ActAld_interp, ϕ_ActAld_jx, T, fluxes)
+j_mean_ActAld(p_hPa, fluxes) = j_mean(σ_ActAld_interp, ϕ_ActAld_jx, p_hPa, fluxes)
 j_mean_CH2Cl2(T, fluxes) = j_mean(σ_CH2Cl2_interp, ϕ_CH2Cl2_jx, T, fluxes)
 j_mean_O2(T, fluxes) = j_mean(σ_O2_interp, ϕ_O2_jx, T, fluxes)
 j_mean_BrNO3(T, fluxes) = j_mean(σ_BrNO3_interp, ϕ_BrNO3_jx, T, fluxes)
@@ -1183,7 +1189,7 @@ j_mean_NO2(T, fluxes) = j_mean(σ_NO2_interp, ϕ_NO2_jx, T, fluxes)
 j_mean_CH3OOH(T, fluxes) = j_mean(σ_CH3OOH_interp, ϕ_CH3OOH_jx, T, fluxes)
 j_mean_GlyAld(T, fluxes) = j_mean(σ_GlyAld_interp, ϕ_GlyAld_jx, T, fluxes)
 j_mean_H2COa(T, fluxes) = j_mean(σ_H2COa_interp, ϕ_H2COa_jx, T, fluxes)
-j_mean_MGlyxl(T, fluxes) = j_mean(σ_MGlyxl_interp, ϕ_MGlyxl_jx, T, fluxes)
+j_mean_MGlyxl(p_hPa, fluxes) = j_mean(σ_MGlyxl_interp, ϕ_MGlyxl_jx, p_hPa, fluxes)
 j_mean_HOBr(T, fluxes) = j_mean(σ_HOBr_interp, ϕ_HOBr_jx, T, fluxes)
 j_mean_NO3a(T, fluxes) = j_mean(σ_NO3_interp, ϕ_NO3_jx, T, fluxes) .* 0.886
 j_mean_NO3b(T, fluxes) = j_mean(σ_NO3_interp, ϕ_NO3_jx, T, fluxes) .* 0.114
@@ -1388,9 +1394,9 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_PAN ~ j_mean_PAN(T / T_unit, flux_vars);
         j_H2402 ~ j_mean_H2402(T / T_unit, flux_vars);
         j_PrAld ~ j_mean_PrAld(T / T_unit, flux_vars);
-        j_MeVKa ~ j_mean_MeVKa(T / T_unit, flux_vars);
-        j_MeVKb ~ j_mean_MeVKb(T / T_unit, flux_vars);
-        j_MeVKc ~ j_mean_MeVKc(T / T_unit, flux_vars);
+        j_MeVKa ~ j_mean_MeVKa(P / P_unit / 100, flux_vars);
+        j_MeVKb ~ j_mean_MeVKb(P / P_unit / 100, flux_vars);
+        j_MeVKc ~ j_mean_MeVKc(P / P_unit / 100, flux_vars);
         j_ClNO3b ~ j_mean_ClNO3b(T / T_unit, flux_vars);
         j_F113 ~ j_mean_F113(T / T_unit, flux_vars);
         j_HNO4 ~ j_mean_HNO4(T / T_unit, flux_vars);
@@ -1407,7 +1413,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_Cl2 ~ j_mean_Cl2(T / T_unit, flux_vars);
         j_CH3I ~ j_mean_CH3I(T / T_unit, flux_vars);
         j_HNO2 ~ j_mean_HNO2(T / T_unit, flux_vars);
-        j_Aceta ~ j_mean_Aceta(T / T_unit, flux_vars);
+        j_Aceta ~ j_mean_Aceta(P / P_unit / 100, flux_vars);
         j_MeCCl3 ~ j_mean_MeCCl3(T / T_unit, flux_vars);
         j_Cl2O2 ~ j_mean_Cl2O2(T / T_unit, flux_vars);
         j_CH3Br ~ j_mean_CH3Br(T / T_unit, flux_vars);
@@ -1417,13 +1423,13 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_F141b ~ j_mean_F141b(T / T_unit, flux_vars);
         j_O3 ~ j_mean_O3(T / T_unit, flux_vars);
         j_ClNO3a ~ j_mean_ClNO3a(T / T_unit, flux_vars);
-        j_ActAld ~ j_mean_ActAld(T / T_unit, flux_vars);
+        j_ActAld ~ j_mean_ActAld(P / P_unit / 100, flux_vars);
         j_CH2Cl2 ~ j_mean_CH2Cl2(T / T_unit, flux_vars);
         j_O2 ~ j_mean_O2(T / T_unit, flux_vars);
         j_BrNO3 ~ j_mean_BrNO3(T / T_unit, flux_vars);
         j_GlyAld ~ j_mean_GlyAld(T / T_unit, flux_vars);
         j_H2COa ~ j_mean_H2COa(T / T_unit, flux_vars);
-        j_MGlyxl ~ j_mean_MGlyxl(T / T_unit, flux_vars);
+        j_MGlyxl ~ j_mean_MGlyxl(P / P_unit / 100, flux_vars);
         j_HOBr ~ j_mean_HOBr(T / T_unit, flux_vars);
         j_NO3a ~ j_mean_NO3a(T / T_unit, flux_vars);
         j_NO3b ~ j_mean_NO3b(T / T_unit, flux_vars);

--- a/src/Fast-JX.jl
+++ b/src/Fast-JX.jl
@@ -1131,7 +1131,7 @@ j_mean_N2O5(T, fluxes) = j_mean(σ_N2O5_interp, ϕ_N2O5_jx, T, fluxes)
 j_mean_H1301(T, fluxes) = j_mean(σ_H1301_interp, ϕ_H1301_jx, T, fluxes)
 j_mean_CFCl3(T, fluxes) = j_mean(σ_CFCl3_interp, ϕ_CFCl3_jx, T, fluxes)
 j_mean_NO(T, fluxes) = j_mean(σ_NO_interp, ϕ_NO_jx, T, fluxes)
-j_mean_Glyxlc(T, fluxes) = j_mean(σ_Glyxlc_interp, ϕ_Glyxlc_jx, T, fluxes)
+j_mean_Glyxlc(p_hPa, fluxes) = j_mean(σ_Glyxlc_interp, ϕ_Glyxlc_jx, p_hPa, fluxes)
 j_mean_F114(T, fluxes) = j_mean(σ_F114_interp, ϕ_F114_jx, T, fluxes)
 j_mean_CH3NO3(T, fluxes) = j_mean(σ_CH3NO3_interp, ϕ_CH3NO3_jx, T, fluxes)
 j_mean_CHBr3(T, fluxes) = j_mean(σ_CHBr3_interp, ϕ_CHBr3_jx, T, fluxes)
@@ -1141,7 +1141,7 @@ j_mean_OClO(T, fluxes) = j_mean(σ_OClO_interp, ϕ_OClO_jx, T, fluxes)
 j_mean_H1211(T, fluxes) = j_mean(σ_H1211_interp, ϕ_H1211_jx, T, fluxes)
 j_mean_BrO(T, fluxes) = j_mean(σ_BrO_interp, ϕ_BrO_jx, T, fluxes)
 j_mean_CH3Cl(T, fluxes) = j_mean(σ_CH3Cl_interp, ϕ_CH3Cl_jx, T, fluxes)
-j_mean_MEKeto(T, fluxes) = j_mean(σ_MEKeto_interp, ϕ_MEKeto_jx, T, fluxes)
+j_mean_MEKeto(p_hPa, fluxes) = j_mean(σ_MEKeto_interp, ϕ_MEKeto_jx, p_hPa, fluxes)
 j_mean_PAN(T, fluxes) = j_mean(σ_PAN_interp, ϕ_PAN_jx, T, fluxes)
 j_mean_H2402(T, fluxes) = j_mean(σ_H2402_interp, ϕ_H2402_jx, T, fluxes)
 j_mean_PrAld(T, fluxes) = j_mean(σ_PrAld_interp, ϕ_PrAld_jx, T, fluxes)
@@ -1165,7 +1165,7 @@ j_mean_F142b(T, fluxes) = j_mean(σ_F142b_interp, ϕ_F142b_jx, T, fluxes)
 j_mean_F115(T, fluxes) = j_mean(σ_F115_interp, ϕ_F115_jx, T, fluxes)
 j_mean_O31D(T, fluxes) = j_mean(σ_O3_interp, ϕ_O31D_interp, T, fluxes)
 j_mean_CF3I(T, fluxes) = j_mean(σ_CF3I_interp, ϕ_CF3I_jx, T, fluxes)
-j_mean_Glyxla(T, fluxes) = j_mean(σ_Glyxla_interp, ϕ_Glyxla_jx, T, fluxes)
+j_mean_Glyxla(p_hPa, fluxes) = j_mean(σ_Glyxla_interp, ϕ_Glyxla_jx, p_hPa, fluxes)
 j_mean_CCl4(T, fluxes) = j_mean(σ_CCl4_interp, ϕ_CCl4_jx, T, fluxes)
 j_mean_Cl2(T, fluxes) = j_mean(σ_Cl2_interp, ϕ_Cl2_jx, T, fluxes)
 j_mean_CH3I(T, fluxes) = j_mean(σ_CH3I_interp, ϕ_CH3I_jx, T, fluxes)
@@ -1177,7 +1177,7 @@ j_mean_Cl2O2(T, fluxes) = j_mean(σ_Cl2O2_interp, ϕ_Cl2O2_jx, T, fluxes)
 j_mean_CH3Br(T, fluxes) = j_mean(σ_CH3Br_interp, ϕ_CH3Br_jx, T, fluxes)
 j_mean_HNO3(T, fluxes) = j_mean(σ_HNO3_interp, ϕ_HNO3_jx, T, fluxes)
 j_mean_CF2Cl2(T, fluxes) = j_mean(σ_CF2Cl2_interp, ϕ_CF2Cl2_jx, T, fluxes)
-j_mean_Glyxlb(T, fluxes) = j_mean(σ_Glyxlb_interp, ϕ_Glyxlb_jx, T, fluxes)
+j_mean_Glyxlb(p_hPa, fluxes) = j_mean(σ_Glyxlb_interp, ϕ_Glyxlb_jx, p_hPa, fluxes)
 j_mean_F141b(T, fluxes) = j_mean(σ_F141b_interp, ϕ_F141b_jx, T, fluxes)
 j_mean_O3(T, fluxes) = j_mean(σ_O3_interp, ϕ_O3_jx, T, fluxes)
 j_mean_ClNO3a(T, fluxes) = j_mean(σ_ClNO3a_interp, ϕ_ClNO3a_jx, T, fluxes)
@@ -1380,7 +1380,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_H1301 ~ j_mean_H1301(T / T_unit, flux_vars);
         j_CFCl3 ~ j_mean_CFCl3(T / T_unit, flux_vars);
         j_NO ~ j_mean_NO(T / T_unit, flux_vars);
-        j_Glyxlc ~ j_mean_Glyxlc(T / T_unit, flux_vars);
+        j_Glyxlc ~ j_mean_Glyxlc(P / P_unit / 100, flux_vars);
         j_F114 ~ j_mean_F114(T / T_unit, flux_vars);
         j_CH3NO3 ~ j_mean_CH3NO3(T / T_unit, flux_vars);
         j_CHBr3 ~ j_mean_CHBr3(T / T_unit, flux_vars);
@@ -1390,7 +1390,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_H1211 ~ j_mean_H1211(T / T_unit, flux_vars);
         j_BrO ~ j_mean_BrO(T / T_unit, flux_vars);
         j_CH3Cl ~ j_mean_CH3Cl(T / T_unit, flux_vars);
-        j_MEKeto ~ j_mean_MEKeto(T / T_unit, flux_vars);
+        j_MEKeto ~ j_mean_MEKeto(P / P_unit / 100, flux_vars);
         j_PAN ~ j_mean_PAN(T / T_unit, flux_vars);
         j_H2402 ~ j_mean_H2402(T / T_unit, flux_vars);
         j_PrAld ~ j_mean_PrAld(T / T_unit, flux_vars);
@@ -1408,7 +1408,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_F115 ~ j_mean_F115(T / T_unit, flux_vars);
         j_O31D ~ j_mean_O31D(T / T_unit, flux_vars);
         j_CF3I ~ j_mean_CF3I(T / T_unit, flux_vars);
-        j_Glyxla ~ j_mean_Glyxla(T / T_unit, flux_vars);
+        j_Glyxla ~ j_mean_Glyxla(P / P_unit / 100, flux_vars);
         j_CCl4 ~ j_mean_CCl4(T / T_unit, flux_vars);
         j_Cl2 ~ j_mean_Cl2(T / T_unit, flux_vars);
         j_CH3I ~ j_mean_CH3I(T / T_unit, flux_vars);
@@ -1419,7 +1419,7 @@ function FastJX(t_ref::AbstractFloat; name = :FastJX, domaininfo = nothing)
         j_CH3Br ~ j_mean_CH3Br(T / T_unit, flux_vars);
         j_HNO3 ~ j_mean_HNO3(T / T_unit, flux_vars);
         j_CF2Cl2 ~ j_mean_CF2Cl2(T / T_unit, flux_vars);
-        j_Glyxlb ~ j_mean_Glyxlb(T / T_unit, flux_vars);
+        j_Glyxlb ~ j_mean_Glyxlb(P / P_unit / 100, flux_vars);
         j_F141b ~ j_mean_F141b(T / T_unit, flux_vars);
         j_O3 ~ j_mean_O3(T / T_unit, flux_vars);
         j_ClNO3a ~ j_mean_ClNO3a(T / T_unit, flux_vars);

--- a/src/interpolations_FastJX.jl
+++ b/src/interpolations_FastJX.jl
@@ -13,6 +13,10 @@ end
 
 const interpolations_18_const = tuple(interpolations_18_troposphere...)
 
+# Fast-JX species whose cross-section tables are PRESSURE-interpolated
+# (SQQ='p' in FJX_spec.dat: rows p177/p566/p999 hPa) — see Fast-JX.jl.
+const _FJX_PRESSURE_AXIS_J = (:MeVKa, :MeVKb, :MeVKc, :Aceta, :ActAld, :MGlyxl)
+
 # Create symbolic wrapper functions for each interpolation
 flux_interp_1(P, csa) = interpolations_18_const[1](ustrip(P), ustrip(csa))
 flux_interp_2(P, csa) = interpolations_18_const[2](ustrip(P), ustrip(csa))
@@ -232,7 +236,13 @@ function FastJX_interpolation_troposphere(
         nm = Symbol(:j_, sp)
         v = only(@variables $nm(t) [unit = u"s^-1"])
         push!(jvars, v)
-        push!(jeqs, v ~ meanf(T / T_unit, flux_vars))
+        # Pressure-interpolated Fast-JX species (FJX_spec.dat p177/p566/p999 rows,
+        # hPa): their sigma axes are pressures, so pass P in hPa, not temperature.
+        if sp in _FJX_PRESSURE_AXIS_J
+            push!(jeqs, v ~ meanf(P / P_unit / 100, flux_vars))
+        else
+            push!(jeqs, v ~ meanf(T / T_unit, flux_vars))
+        end
     end
     iO31D = findfirst(p -> p[1] === :O31D, jlist)
     @assert iO31D !== nothing "species list must include :O31D (needed for j_o32OH)"

--- a/src/interpolations_FastJX.jl
+++ b/src/interpolations_FastJX.jl
@@ -15,7 +15,8 @@ const interpolations_18_const = tuple(interpolations_18_troposphere...)
 
 # Fast-JX species whose cross-section tables are PRESSURE-interpolated
 # (SQQ='p' in FJX_spec.dat: rows p177/p566/p999 hPa) — see Fast-JX.jl.
-const _FJX_PRESSURE_AXIS_J = (:MeVKa, :MeVKb, :MeVKc, :Aceta, :ActAld, :MGlyxl)
+const _FJX_PRESSURE_AXIS_J = (:MeVKa, :MeVKb, :MeVKc, :Aceta, :ActAld, :MGlyxl,
+    :MEKeto, :Glyxla, :Glyxlb, :Glyxlc)  # all 8 FJX_spec.dat p-prefixed blocks
 
 # Create symbolic wrapper functions for each interpolation
 flux_interp_1(P, csa) = interpolations_18_const[1](ustrip(P), ustrip(csa))

--- a/test/fastjx_test.jl
+++ b/test/fastjx_test.jl
@@ -161,7 +161,9 @@ end
     j_Glyxlc_value = j_Glyxlc_func(prob)
 
     @test j_Glyxlc_value ≈
-        GasChem.j_mean_Glyxlc(298.0, get_fluxes(3600 * 12.0, 40.0, -97.0, 101325)) rtol = 1.0e-6
+        # Glyxlc is a pressure-interpolated FJX species: the built system evaluates
+        # its sigma at P/100 hPa (= 1013.25 for P=101325 Pa), not at temperature.
+        GasChem.j_mean_Glyxlc(101325 / 100, get_fluxes(3600 * 12.0, 40.0, -97.0, 101325)) rtol = 1.0e-6
 end
 
 @testitem "Ensure Cos SZA is non-allocating" begin


### PR DESCRIPTION
## Summary

`FJX_spec.dat` marks four species' cross-section tables with the **`p` prefix** (rows `p177 / p566 / p999`): the interpolation axis is mid-layer **pressure in hPa**, and Cloud-J's `JRATET` dispatches them on the `SQQ='p'` flag, calling `X_interp` with `PP` (hPa). The port passed **temperature (Kelvin)** into these axes — evaluating σ at "P = T kelvin hPa" (~288 hPa at the surface instead of ~1000 hPa).

Affected channels and surface-J inflation (all **8** FJX `p`-blocks): **J_ActAld ≈ 2.4×, J_MeVK(a/b/c) ≈ 2.3×, J_MEKeto ≈ 2.05×, J_MGlyxl ≈ 2.0×, J_Glyxla ≈ 1.6×**; J_Aceta is *0.92×* (the T-eval under-estimated it, so the fix slightly raises it); J_Glyxlb’s σ is pressure-flat (unchanged). Correction to an earlier revision of this description, which mis-stated J_Aceta as ~2.1× — that figure belongs to MEKeto. Carbonyl photolysis is an HOx source, so full-mechanism runs get a spurious radical boost.

## Change

- All eight `p`-block species (`MeVKa/b/c`, `Aceta`, `ActAld`, `MGlyxl`, `MEKeto`, `Glyxla`, `Glyxlb`, `Glyxlc`) now take pressure in hPa (self-documenting arg rename), with a comment tying them to the FJX `p`-rows.
- Both call paths pass `P / (100 P_unit)`: the online `FastJX()` equations, and the `FastJX_interpolation_troposphere()` builder via a species-key dispatch set (`_FJX_PRESSURE_AXIS_J`).
- Verified in the **built equations** on both paths: they now read `clamp(P / (100P_unit), 177.0, 999.0)`; `mtkcompile` passes for both constructors.

## Scope

The SuperFast coupler wires none of these channels — SuperFast runs unaffected. Full GEOS-Chem-mechanism runs (`mech=:all`) are affected. At P > 999 hPa the `Flat()` clamp mirrors Cloud-J's own edge handling.

Found by a numerical equivalence audit of this stack against GEOS-Chem Classic 14.7.1 / Cloud-J v8.0 (`p`-prefix provenance + recomputed J ratios). Part of the Stage-6 series in #225. Independent of #234 (tables) — mergeable in any order.
